### PR TITLE
feat: enhance genesis_generator with single-node support & CLI improvements

### DIFF
--- a/cmd/genesis_generator/genesis_generator.go
+++ b/cmd/genesis_generator/genesis_generator.go
@@ -188,6 +188,31 @@ func (g *genesisGenerator) wbftChainConfig() {
 		"validators":    vals,
 		"blsPublicKeys": blsKeys,
 	}
+	g.Genesis.Config.Anzeon.SystemContracts.NativeCoinAdapter.Params = map[string]string{
+		"masterMinter":  "0x0000000000000000000000000000000000001002",
+		"minters":       "0x0000000000000000000000000000000000001003",
+		"minterAllowed": "10000000000000000000000000000",
+		"name":          "KRC1",
+		"symbol":        "KRC1",
+		"decimals":      "18",
+		"currency":      "KRW",
+	}
+	g.Genesis.Config.Anzeon.SystemContracts.GovMasterMinter.Params = map[string]string{
+		"quorum":             "1",
+		"expiry":             "604800",
+		"members":            vals,
+		"memberVersion":      "1",
+		"fiatToken":          "0x0000000000000000000000000000000000001000",
+		"maxMinterAllowance": "10000000000000000000000000000",
+	}
+	g.Genesis.Config.Anzeon.SystemContracts.GovMinter.Params = map[string]string{
+		"quorum":        "1",
+		"expiry":        "604800",
+		"members":       vals,
+		"memberVersion": "1",
+		"fiatToken":     "0x0000000000000000000000000000000000001000",
+	}
+
 	// you can add config file for static nodes if you want
 	fmt.Println()
 	fmt.Println("Want to generate config.toml file to configure static nodes to connect?")

--- a/cmd/genesis_generator/genesis_generator.go
+++ b/cmd/genesis_generator/genesis_generator.go
@@ -230,6 +230,16 @@ func (g *genesisGenerator) setAnzeonConfig(validators []common.Address, blsPubli
 	}
 }
 
+func genDefaultConfigFile() {
+	var buf bytes.Buffer
+	// Write Node.P2P section with StaticNodes
+	buf.WriteString("[Node.P2P]\n")
+	buf.WriteString("StaticNodes = [\n")
+	buf.WriteString("\n]\n")
+
+	writeConfigFile(buf, ".")
+}
+
 func (g *genesisGenerator) wbftSingleNodeConfig() {
 	fmt.Println()
 	fmt.Println("Enter the path to the nodekey file to use (default: ./nodekey):")
@@ -254,6 +264,8 @@ func (g *genesisGenerator) wbftSingleNodeConfig() {
 	blsPubKeys := []string{account.blsPubKey}
 
 	g.setAnzeonConfig(validators, blsPubKeys)
+
+	genDefaultConfigFile()
 
 	g.Genesis.Alloc[account.address] = types.Account{
 		Balance: new(big.Int).Lsh(big.NewInt(1), 256-7), // 2^256 / 128 (allow many pre-funds without balance overflows)
@@ -424,19 +436,23 @@ func genConfigFile() {
 		fmt.Println()
 		fmt.Printf("Which folder to save the config.toml into? (default = current)\n")
 		folder := readDefaultString(".")
-		if err := os.MkdirAll(folder, 0755); err != nil {
-			log.Error("Failed to create spec folder", "folder", folder, "err", err)
-			return
-		}
-		configPath := filepath.Join(folder, "config.toml")
-		if err := os.WriteFile(configPath, buf.Bytes(), 0644); err != nil {
-			log.Error("Failed to save config file", "err", err)
-			return
-		}
-		log.Info("Saved config.toml file", "path", configPath)
+		writeConfigFile(buf, folder)
 	} else {
 		fmt.Println(buf.String())
 	}
+}
+
+func writeConfigFile(buf bytes.Buffer, folder string) {
+	if err := os.MkdirAll(folder, 0755); err != nil {
+		log.Error("Failed to create spec folder", "folder", folder, "err", err)
+		return
+	}
+	configPath := filepath.Join(folder, "config.toml")
+	if err := os.WriteFile(configPath, buf.Bytes(), 0644); err != nil {
+		log.Error("Failed to save config file", "err", err)
+		return
+	}
+	log.Info("Saved config.toml file", "path", configPath)
 }
 
 // validateEnodeURL checks if the given string is a valid enode URL

--- a/cmd/genesis_generator/genesis_generator.go
+++ b/cmd/genesis_generator/genesis_generator.go
@@ -100,7 +100,7 @@ func (g *genesisGenerator) makeGenesis() {
 	switch {
 	case choice == "1" || choice == "":
 		fmt.Println()
-		fmt.Println("Which type of network would you like to configure? (default single-node)")
+		fmt.Println("Which type of network would you like to configure? (default = single-node)")
 		fmt.Println(" 1. single-node")
 		fmt.Println(" 2. multi-node")
 
@@ -185,8 +185,9 @@ func deriveAccount(nodeKey *ecdsa.PrivateKey) (*NodeAccount, error) {
 	return &NodeAccount{address, blsPubKey}, nil
 }
 
-func (g *genesisGenerator) setAnzeonConfig(validators []common.Address, blsPublicKeys []string) {
+func (g *genesisGenerator) setAnzeonConfig(validators []common.Address, blsPublicKeys []string, quorum int) {
 	g.Genesis.Config.Anzeon = params.DefaultAnzeonConfig
+
 	var vals, blsKeys string
 	for i, val := range validators {
 		g.Genesis.Config.Anzeon.Init.Validators = append(g.Genesis.Config.Anzeon.Init.Validators, val)
@@ -196,9 +197,11 @@ func (g *genesisGenerator) setAnzeonConfig(validators []common.Address, blsPubli
 	}
 	vals = strings.TrimRight(vals, ",")
 	blsKeys = strings.TrimRight(blsKeys, ",")
+
+	quorumStr := strconv.Itoa(quorum)
 	g.Genesis.Config.Anzeon.SystemContracts.GovValidator.Params = map[string]string{
 		"members":       vals,
-		"quorum":        "1",
+		"quorum":        quorumStr,
 		"expiry":        "604800",
 		"memberVersion": "1",
 		"validators":    vals,
@@ -214,7 +217,7 @@ func (g *genesisGenerator) setAnzeonConfig(validators []common.Address, blsPubli
 		"currency":      "KRW",
 	}
 	g.Genesis.Config.Anzeon.SystemContracts.GovMasterMinter.Params = map[string]string{
-		"quorum":             "1",
+		"quorum":             quorumStr,
 		"expiry":             "604800",
 		"members":            vals,
 		"memberVersion":      "1",
@@ -222,7 +225,7 @@ func (g *genesisGenerator) setAnzeonConfig(validators []common.Address, blsPubli
 		"maxMinterAllowance": "10000000000000000000000000000",
 	}
 	g.Genesis.Config.Anzeon.SystemContracts.GovMinter.Params = map[string]string{
-		"quorum":        "1",
+		"quorum":        quorumStr,
 		"expiry":        "604800",
 		"members":       vals,
 		"memberVersion": "1",
@@ -263,7 +266,9 @@ func (g *genesisGenerator) wbftSingleNodeConfig() {
 	validators := []common.Address{account.address}
 	blsPubKeys := []string{account.blsPubKey}
 
-	g.setAnzeonConfig(validators, blsPubKeys)
+	g.Genesis.Difficulty = types.WBFTDefaultDifficulty
+
+	g.setAnzeonConfig(validators, blsPubKeys, 1)
 
 	genDefaultConfigFile()
 
@@ -296,7 +301,23 @@ func (g *genesisGenerator) wbftChainConfig() {
 		}
 	}
 
-	g.setAnzeonConfig(validators, blsPublicKeys)
+	fmt.Println()
+	fmt.Println("Enter the quorum for governance: (default = 1)")
+	var quorum int
+	for {
+		quorum = readDefaultInt(1)
+		if quorum < 1 {
+			fmt.Printf("Quorum must be at least 1\n")
+			continue
+		}
+		if quorum > len(validators) {
+			fmt.Printf("Quorum cannot exceed number of validators: %d\n", len(validators))
+			continue
+		}
+		break
+	}
+
+	g.setAnzeonConfig(validators, blsPublicKeys, quorum)
 
 	// you can add config file for static nodes if you want
 	fmt.Println()

--- a/cmd/genesis_generator/genesis_generator.go
+++ b/cmd/genesis_generator/genesis_generator.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"bytes"
+	"crypto/ecdsa"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -31,8 +32,11 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/bls"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 )
@@ -95,7 +99,19 @@ func (g *genesisGenerator) makeGenesis() {
 	choice := read()
 	switch {
 	case choice == "1" || choice == "":
-		g.wbftChainConfig()
+		fmt.Println()
+		fmt.Println("Which type of network would you like to configure? (default single-node)")
+		fmt.Println(" 1. single-node")
+		fmt.Println(" 2. multi-node")
+
+		typeChoice := read()
+		switch {
+		case typeChoice == "1" || typeChoice == "":
+			g.wbftSingleNodeConfig()
+			return
+		case typeChoice == "2":
+			g.wbftChainConfig()
+		}
 
 	case choice == "2":
 		g.ethashConfig()
@@ -152,24 +168,24 @@ func (g *genesisGenerator) makeGenesis() {
 	}
 }
 
-func (g *genesisGenerator) wbftChainConfig() {
-	g.Genesis.Difficulty = types.WBFTDefaultDifficulty
-	fmt.Println()
-	fmt.Println("Which accounts are allowed to seal? (mandatory at least one)")
+type NodeAccount struct {
+	address   common.Address
+	blsPubKey string
+}
 
-	var validators []common.Address
-	var blsPublicKeys []string
-	for {
-		if address := readAddress(); address != nil {
-			validators = append(validators, *address)
-			blsPublicKeys = append(blsPublicKeys, readBLSPubKey())
-			continue
-		}
-		if len(validators) > 0 {
-			break
-		}
+func deriveAccount(nodeKey *ecdsa.PrivateKey) (*NodeAccount, error) {
+	address := crypto.PubkeyToAddress(nodeKey.PublicKey)
+	blsKey, err := bls.DeriveFromECDSA(nodeKey)
+	if err != nil {
+		return nil, err
 	}
+	blsPubKeyBytes := blsKey.PublicKey().Marshal()
+	blsPubKey := hexutil.Encode(blsPubKeyBytes)
 
+	return &NodeAccount{address, blsPubKey}, nil
+}
+
+func (g *genesisGenerator) setAnzeonConfig(validators []common.Address, blsPublicKeys []string) {
 	g.Genesis.Config.Anzeon = params.DefaultAnzeonConfig
 	var vals, blsKeys string
 	for i, val := range validators {
@@ -212,6 +228,63 @@ func (g *genesisGenerator) wbftChainConfig() {
 		"memberVersion": "1",
 		"fiatToken":     "0x0000000000000000000000000000000000001000",
 	}
+}
+
+func (g *genesisGenerator) wbftSingleNodeConfig() {
+	fmt.Println()
+	fmt.Println("Enter the path to the nodekey file to use (default: ./nodekey):")
+
+	var account *NodeAccount
+	for {
+		keyPath := readDefaultString("./nodekey")
+		nodeKey, err := crypto.LoadECDSA(keyPath)
+		if err != nil {
+			fmt.Printf("Failed to load nodekey from '%s': %v\n", keyPath, err)
+			continue
+		}
+		account, err = deriveAccount(nodeKey)
+		if err != nil {
+			fmt.Printf("Failed to derive account from nodekey: %v\n", err)
+			continue
+		}
+		break
+	}
+
+	validators := []common.Address{account.address}
+	blsPubKeys := []string{account.blsPubKey}
+
+	g.setAnzeonConfig(validators, blsPubKeys)
+
+	g.Genesis.Alloc[account.address] = types.Account{
+		Balance: new(big.Int).Lsh(big.NewInt(1), 256-7), // 2^256 / 128 (allow many pre-funds without balance overflows)
+	}
+
+	g.Genesis.Config.ChainID = new(big.Int).SetUint64(uint64(rand.Intn(65536)))
+
+	g.genGenesisFile(".")
+
+	fmt.Println("genesis.json successfully generated")
+}
+
+func (g *genesisGenerator) wbftChainConfig() {
+	g.Genesis.Difficulty = types.WBFTDefaultDifficulty
+	fmt.Println()
+	fmt.Println("Which accounts are allowed to seal? (mandatory at least one)")
+
+	var validators []common.Address
+	var blsPublicKeys []string
+	for {
+		if address := readAddress(); address != nil {
+			validators = append(validators, *address)
+			blsPublicKeys = append(blsPublicKeys, readBLSPubKey())
+			continue
+		}
+		if len(validators) > 0 {
+			break
+		}
+	}
+
+	g.setAnzeonConfig(validators, blsPublicKeys)
 
 	// you can add config file for static nodes if you want
 	fmt.Println()

--- a/cmd/genesis_generator/genesis_generator.go
+++ b/cmd/genesis_generator/genesis_generator.go
@@ -285,6 +285,7 @@ func (g *genesisGenerator) wbftSingleNodeConfig() {
 
 func (g *genesisGenerator) wbftChainConfig() {
 	g.Genesis.Difficulty = types.WBFTDefaultDifficulty
+
 	fmt.Println()
 	fmt.Println("Which accounts are allowed to seal? (mandatory at least one)")
 
@@ -301,13 +302,19 @@ func (g *genesisGenerator) wbftChainConfig() {
 		}
 	}
 
+	minQuorum := 2
+	if len(validators) == 1 {
+		minQuorum = 1
+	}
+
 	fmt.Println()
-	fmt.Println("Enter the quorum for governance: (default = 1)")
+	fmt.Printf("Enter the quorum for governance: (default = %d)\n", minQuorum)
+
 	var quorum int
 	for {
-		quorum = readDefaultInt(1)
-		if quorum < 1 {
-			fmt.Printf("Quorum must be at least 1\n")
+		quorum = readDefaultInt(minQuorum)
+		if quorum < minQuorum {
+			fmt.Printf("Quorum must be at least %d\n", minQuorum)
 			continue
 		}
 		if quorum > len(validators) {

--- a/cmd/genesis_generator/genesis_generator.go
+++ b/cmd/genesis_generator/genesis_generator.go
@@ -245,7 +245,7 @@ func genDefaultConfigFile() {
 
 func (g *genesisGenerator) wbftSingleNodeConfig() {
 	fmt.Println()
-	fmt.Println("Enter the path to the nodekey file to use (default: ./nodekey):")
+	fmt.Println("Enter the path to the nodekey file to use (default = ./nodekey):")
 
 	var account *NodeAccount
 	for {

--- a/cmd/genesis_generator/reader.go
+++ b/cmd/genesis_generator/reader.go
@@ -117,9 +117,12 @@ func readDefaultBigInt(def *big.Int) *big.Int {
 // it to an Ethereum address.
 func readAddress() *common.Address {
 	for {
-		text := promptInput("> 0x")
+		text := promptInput("> ")
 		if text = strings.TrimSpace(text); text == "" {
 			return nil
+		}
+		if strings.HasPrefix(text, "0x") {
+			text = text[2:]
 		}
 		// Make sure it looks ok and return it if so
 		if len(text) != 40 {

--- a/cmd/genesis_generator/reader.go
+++ b/cmd/genesis_generator/reader.go
@@ -118,9 +118,7 @@ func readAddress() *common.Address {
 		if text = strings.TrimSpace(text); text == "" {
 			return nil
 		}
-		if strings.HasPrefix(text, "0x") {
-			text = text[2:]
-		}
+		text = strings.TrimPrefix(text, "0x")
 		// Make sure it looks ok and return it if so
 		if len(text) != 40 {
 			log.Error("Invalid address length, please retry")

--- a/cmd/genesis_generator/reader.go
+++ b/cmd/genesis_generator/reader.go
@@ -24,7 +24,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/console/prompt"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/peterh/liner"
 )
 
 // prompts the user for input with the given prompt string.  Returns when a value is entered.
@@ -33,9 +32,7 @@ func promptInput(p string) string {
 	for {
 		text, err := prompt.Stdin.PromptInput(p)
 		if err != nil {
-			if err != liner.ErrPromptAborted {
-				log.Crit("Failed to read user input", "err", err)
-			}
+			log.Crit("Failed to read user input", "err", err)
 		} else {
 			return text
 		}

--- a/systemcontracts/coin_adapter.go
+++ b/systemcontracts/coin_adapter.go
@@ -31,7 +31,7 @@ const (
 	COIN_ADAPTER_PARAM_CURRENCY       = "currency"
 )
 
-func initializeCoinAdatper(coinAdapterAddress common.Address, param map[string]string, alloc *types.GenesisAlloc) ([]params.StateParam, error) {
+func initializeCoinAdapter(coinAdapterAddress common.Address, param map[string]string, alloc *types.GenesisAlloc) ([]params.StateParam, error) {
 	sp := make([]params.StateParam, 0)
 
 	// SLOT_COIN_ADAPTER_MASTER_MINTER

--- a/systemcontracts/systemcontracts.go
+++ b/systemcontracts/systemcontracts.go
@@ -68,7 +68,7 @@ func GetSystemContractsTransition(systemContracts *params.SystemContracts, alloc
 
 	if systemContracts.NativeCoinAdapter != nil {
 		st.Codes = append(st.Codes, params.CodeParam{Address: systemContracts.NativeCoinAdapter.Address, Code: SystemContractCodes[CONTRACT_COIN_ADAPTER][systemContracts.NativeCoinAdapter.Version]})
-		sp, err := initializeCoinAdatper(systemContracts.NativeCoinAdapter.Address, systemContracts.NativeCoinAdapter.Params, alloc)
+		sp, err := initializeCoinAdapter(systemContracts.NativeCoinAdapter.Address, systemContracts.NativeCoinAdapter.Params, alloc)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for **single-node mode** in the `genesis_generator`, improving developer UX, simplifying setup, and hardening configuration initialization behavior.  
It also introduces default parameter handling for `SystemContracts` to prevent node initialization failures from generated `genesis.json`.

---

## Changes

### Features
- **`feat: add single-node config for wbft`**  
  Implements WBFT-specific single-node configuration: derives validator and BLS key from `nodekey`, sets up validators, alloc, and Chain ID.
- **`feat: generate default config.toml for single-node`**  
  Automatically generates a basic config.toml template.
- **`feat: prompt user for quorum input`**  
  Adds an interactive CLI prompt for governance quorum value instead of using a hardcoded default.

### Fixes & Improvements
- **`fix: add default SystemContracts parameters to prevent node initialization failure`**  
  Adds default parameter initialization for `SystemContracts` to ensure successful node initialization from `genesis.json` without missing configuration values.
- **`fix: enable ctrl-c to exit genesis generator`**  
  Allows users to gracefully abort the generator via Ctrl+C.
- **`fix: remove hex prefix from input address`**  
  Normalizes address input by stripping the `0x` prefix before parsing.
- **`fix: fix typo`**  
  From `initializeCoinAdatper` to `initializeCoinAdapter`

---

## Implementation Details
- **Single-node mode workflow:**  
  - Reads `nodekey` (default: `./nodekey`) and derives validator address and BLS public key.  
  - Initializes WBFT configuration with validator and BLS sets.  
  - Generates both `genesis.json` and `config.toml` automatically.  

- **Configuration defaults:**  
  - Adds default `SystemContracts` parameters to prevent initialization failures caused by missing values.  
  - Multi-node configuration remains unchanged for backward compatibility.  

- **CLI/UX refinements:**  
  - Supports graceful termination on SIGINT (Ctrl+C).

---

## Checklist
- [x] Single-node mode generator flow verified  
- [x] Default `config.toml` generated automatically  
- [x] `SystemContracts` defaults applied correctly  
- [x] Quorum input validated  
- [x] Ctrl+C termination handled gracefully  
- [x] Multi-node configuration unaffected  

---

## Related Issues
Close: #20 
