### PR TITLE
fix: include missing Extra field

### DIFF
--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -80,6 +80,8 @@ type StateDB interface {
 	AddLog(*types.Log)
 	AddPreimage(common.Hash, []byte)
 
+	GetExtra(common.Address) uint64
+
 	IsBlacklisted(addr common.Address) bool
 	SetBlacklisted(addr common.Address)
 	ClearBlacklisted(addr common.Address)

--- a/eth/tracers/internal/tracetest/prestate_test.go
+++ b/eth/tracers/internal/tracetest/prestate_test.go
@@ -41,6 +41,7 @@ type account struct {
 	Code    string                      `json:"code"`
 	Nonce   uint64                      `json:"nonce"`
 	Storage map[common.Hash]common.Hash `json:"storage"`
+	Extra   uint64                      `json:"extra,omitempty"`
 }
 
 // testcase defines a single test to check the stateDiff tracer against.

--- a/eth/tracers/internal/tracetest/testdata/prestate_tracer/extra_field.json
+++ b/eth/tracers/internal/tracetest/testdata/prestate_tracer/extra_field.json
@@ -1,0 +1,69 @@
+{
+    "context": {
+        "difficulty": "3502894804",
+        "gasLimit": "4722976",
+        "miner": "0x1585936b53834b021f68cc13eeefdec2efc8e724",
+        "number": "2289806",
+        "timestamp": "1513601314"
+    },
+    "genesis": {
+        "alloc": {
+            "0x0024f658a46fbb89d8ac105e98d7ac7cbbaf27c5": {
+                "balance": "0x0",
+                "code": "0x",
+                "nonce": "22",
+                "storage": {}
+            },
+            "0x3b873a919aa0512d5a0f09e6dcceaa4a6727fafe": {
+                "balance": "0x4d87094125a369d9bd5",
+                "code": "0x",
+                "nonce": "1",
+                "storage": {}
+            },
+            "0xb436ba50d378d4bbc8660d312a13df6af6e89dfb": {
+                "balance": "0x1780d77678137ac1b775",
+                "code": "0x",
+                "nonce": "29072",
+                "storage": {},
+                "extra": 12345
+            }
+        },
+        "config": {
+            "byzantiumBlock": 1700000,
+            "chainId": 3,
+            "daoForkSupport": true,
+            "eip150Block": 0,
+            "eip150Hash": "0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d",
+            "eip155Block": 10,
+            "eip158Block": 10,
+            "ethash": {},
+            "homesteadBlock": 0
+        },
+        "difficulty": "3509749784",
+        "extraData": "0x4554482e45544846414e532e4f52472d4641313738394444",
+        "gasLimit": "4727564",
+        "hash": "0x609948ac3bd3c00b7736b933248891d6c901ee28f066241bddb28f4e00a9f440",
+        "miner": "0xbbf5029fd710d227630c8b7d338051b8e76d50b3",
+        "mixHash": "0xb131e4507c93c7377de00e7c271bf409ec7492767142ff0f45c882f8068c2ada",
+        "nonce": "0x4eb12e19c16d43da",
+        "number": "2289805",
+        "stateRoot": "0xc7f10f352bff82fac3c2999d3085093d12652e19c7fd32591de49dc5d91b4f1f",
+        "timestamp": "1513601261",
+        "totalDifficulty": "7143276353481064"
+    },
+    "input": "0xf88b8271908506fc23ac0083015f90943b873a919aa0512d5a0f09e6dcceaa4a6727fafe80a463e4bff40000000000000000000000000024f658a46fbb89d8ac105e98d7ac7cbbaf27c52aa0bdce0b59e8761854e857fe64015f06dd08a4fbb7624f6094893a79a72e6ad6bea01d9dde033cff7bb235a3163f348a6d7ab8d6b52bc0963a95b91612e40ca766a4",
+    "result": {
+        "0x3b873a919aa0512d5a0f09e6dcceaa4a6727fafe": {
+            "balance": "0x4d87094125a369d9bd5",
+            "nonce": 1
+        },
+        "0xb436ba50d378d4bbc8660d312a13df6af6e89dfb": {
+            "balance": "0x1780d77678137ac1b775",
+            "nonce": 29072,
+            "extra": 12345
+        },
+        "0x1585936b53834b021f68cc13eeefdec2efc8e724": {
+            "balance": "0x0"
+        }
+    }
+}

--- a/eth/tracers/native/gen_account_json.go
+++ b/eth/tracers/native/gen_account_json.go
@@ -17,12 +17,14 @@ func (a account) MarshalJSON() ([]byte, error) {
 	type account struct {
 		Balance *hexutil.Big                `json:"balance,omitempty"`
 		Code    hexutil.Bytes               `json:"code,omitempty"`
+		Extra   uint64                      `json:"extra,omitempty"`
 		Nonce   uint64                      `json:"nonce,omitempty"`
 		Storage map[common.Hash]common.Hash `json:"storage,omitempty"`
 	}
 	var enc account
 	enc.Balance = (*hexutil.Big)(a.Balance)
 	enc.Code = a.Code
+	enc.Extra = a.Extra
 	enc.Nonce = a.Nonce
 	enc.Storage = a.Storage
 	return json.Marshal(&enc)
@@ -33,6 +35,7 @@ func (a *account) UnmarshalJSON(input []byte) error {
 	type account struct {
 		Balance *hexutil.Big                `json:"balance,omitempty"`
 		Code    *hexutil.Bytes              `json:"code,omitempty"`
+		Extra   *uint64                     `json:"extra,omitempty"`
 		Nonce   *uint64                     `json:"nonce,omitempty"`
 		Storage map[common.Hash]common.Hash `json:"storage,omitempty"`
 	}
@@ -45,6 +48,9 @@ func (a *account) UnmarshalJSON(input []byte) error {
 	}
 	if dec.Code != nil {
 		a.Code = *dec.Code
+	}
+	if dec.Extra != nil {
+		a.Extra = *dec.Extra
 	}
 	if dec.Nonce != nil {
 		a.Nonce = *dec.Nonce

--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -41,6 +41,7 @@ type state = map[common.Address]*account
 type account struct {
 	Balance *big.Int                    `json:"balance,omitempty"`
 	Code    []byte                      `json:"code,omitempty"`
+	Extra   uint64                      `json:"extra,omitempty"`
 	Nonce   uint64                      `json:"nonce,omitempty"`
 	Storage map[common.Hash]common.Hash `json:"storage,omitempty"`
 }
@@ -211,6 +212,11 @@ func (t *prestateTracer) CaptureTxEnd(restGas uint64) {
 			modified = true
 			postAccount.Code = newCode
 		}
+		newExtra := t.env.StateDB.GetExtra(addr)
+		if newExtra != t.pre[addr].Extra {
+			modified = true
+			postAccount.Extra = newExtra
+		}
 
 		for key, val := range state.Storage {
 			// don't include the empty slot
@@ -283,6 +289,7 @@ func (t *prestateTracer) lookupAccount(addr common.Address) {
 		Nonce:   t.env.StateDB.GetNonce(addr),
 		Code:    t.env.StateDB.GetCode(addr),
 		Storage: make(map[common.Hash]common.Hash),
+		Extra:   t.env.StateDB.GetExtra(addr),
 	}
 }
 

--- a/ethclient/gethclient/gethclient.go
+++ b/ethclient/gethclient/gethclient.go
@@ -69,6 +69,7 @@ type AccountResult struct {
 	Nonce        uint64          `json:"nonce"`
 	StorageHash  common.Hash     `json:"storageHash"`
 	StorageProof []StorageResult `json:"storageProof"`
+	Extra        uint64          `json:"extra,omitempty"`
 }
 
 // StorageResult provides a proof for a key-value pair.
@@ -95,6 +96,7 @@ func (ec *Client) GetProof(ctx context.Context, account common.Address, keys []s
 		Nonce        hexutil.Uint64  `json:"nonce"`
 		StorageHash  common.Hash     `json:"storageHash"`
 		StorageProof []storageResult `json:"storageProof"`
+		Extra        hexutil.Uint64  `json:"extra,omitempty"`
 	}
 
 	// Avoid keys being 'null'.
@@ -121,6 +123,7 @@ func (ec *Client) GetProof(ctx context.Context, account common.Address, keys []s
 		CodeHash:     res.CodeHash,
 		StorageHash:  res.StorageHash,
 		StorageProof: storageResults,
+		Extra:        uint64(res.Extra),
 	}
 	return &result, err
 }

--- a/ethclient/gethclient/gethclient_test.go
+++ b/ethclient/gethclient/gethclient_test.go
@@ -568,3 +568,128 @@ func testCallContractWithBlockOverrides(t *testing.T, client *rpc.Client) {
 		t.Fatalf("unexpected result: %x", res)
 	}
 }
+
+// TestGetProofWithExtraFields tests the Extra field in GetProof responses
+// with various account configurations
+func TestGetProofWithExtraFields(t *testing.T) {
+	// Test case 1: All accounts have Extra field set
+	t.Run("AllAccountsWithExtra", func(t *testing.T) {
+		addr1 := common.HexToAddress("0x1111")
+		addr2 := common.HexToAddress("0x2222")
+		addr3 := common.HexToAddress("0x3333")
+
+		genesis := &core.Genesis{
+			Config: params.AllEthashProtocolChanges,
+			Alloc: types.GenesisAlloc{
+				addr1: {Balance: big.NewInt(1e18), Extra: 0x1234567890abcdef},
+				addr2: {Balance: big.NewInt(2e18), Extra: 0xfedcba0987654321},
+				addr3: {Balance: big.NewInt(3e18), Extra: 0xaaaaaaaaaaaaaaaa},
+			},
+			ExtraData: []byte("test genesis"),
+			Timestamp: 9000,
+		}
+
+		testExtraFieldsWithGenesis(t, genesis, []extraTestCase{
+			{addr1, 0x1234567890abcdef},
+			{addr2, 0xfedcba0987654321},
+			{addr3, 0xaaaaaaaaaaaaaaaa},
+		})
+	})
+
+	// Test case 2: Mixed - some accounts with Extra, some without
+	t.Run("MixedAccountsWithExtra", func(t *testing.T) {
+		addr1 := common.HexToAddress("0x4444")
+		addr2 := common.HexToAddress("0x5555")
+		addr3 := common.HexToAddress("0x6666")
+		addr4 := common.HexToAddress("0x7777")
+
+		genesis := &core.Genesis{
+			Config: params.AllEthashProtocolChanges,
+			Alloc: types.GenesisAlloc{
+				addr1: {Balance: big.NewInt(1e18), Extra: 0x1111111111111111},
+				addr2: {Balance: big.NewInt(2e18)},                            // No Extra (default 0)
+				addr3: {Balance: big.NewInt(3e18), Extra: 0},                  // Explicit 0
+				addr4: {Balance: big.NewInt(4e18), Extra: 0xffffffffffffffff}, // Max uint64
+			},
+			ExtraData: []byte("test genesis"),
+			Timestamp: 9000,
+		}
+
+		testExtraFieldsWithGenesis(t, genesis, []extraTestCase{
+			{addr1, 0x1111111111111111},
+			{addr2, 0},                  // No Extra field
+			{addr3, 0},                  // Explicit zero
+			{addr4, 0xffffffffffffffff}, // Max value
+		})
+	})
+}
+
+type extraTestCase struct {
+	addr  common.Address
+	extra uint64
+}
+
+// testExtraFieldsWithGenesis is a helper function that creates a backend with
+// the given genesis and tests Extra field for specified accounts
+func testExtraFieldsWithGenesis(t *testing.T, genesis *core.Genesis, testCases []extraTestCase) {
+	// Generate blocks
+	generate := func(i int, g *core.BlockGen) {
+		g.OffsetTime(5)
+		g.SetExtra([]byte("test"))
+	}
+	_, blocks, _ := core.GenerateChainWithGenesis(genesis, ethash.NewFaker(), 1, generate)
+	blocks = append([]*types.Block{genesis.ToBlock()}, blocks...)
+
+	// Create node
+	n, err := node.New(&node.Config{})
+	if err != nil {
+		t.Fatalf("can't create new node: %v", err)
+	}
+	defer n.Close()
+
+	// Create Ethereum Service
+	config := &ethconfig.Config{Genesis: genesis}
+	ethservice, err := eth.New(n, config)
+	if err != nil {
+		t.Fatalf("can't create new ethereum service: %v", err)
+	}
+	filterSystem := filters.NewFilterSystem(ethservice.APIBackend, filters.Config{})
+	n.RegisterAPIs([]rpc.API{{
+		Namespace: "eth",
+		Service:   filters.NewFilterAPI(filterSystem, false),
+	}})
+
+	// Start the node
+	if err := n.Start(); err != nil {
+		t.Fatalf("can't start test node: %v", err)
+	}
+
+	// Import blocks
+	if _, err := ethservice.BlockChain().InsertChain(blocks[1:]); err != nil {
+		t.Fatalf("can't import test blocks: %v", err)
+	}
+
+	// Get client
+	client := n.Attach()
+	defer client.Close()
+
+	ec := New(client)
+
+	// Test each account
+	for _, tc := range testCases {
+		result, err := ec.GetProof(context.Background(), tc.addr, nil, nil)
+		if err != nil {
+			t.Fatalf("GetProof failed for %v: %v", tc.addr, err)
+		}
+
+		if result.Address != tc.addr {
+			t.Fatalf("unexpected address, have: %v want: %v", result.Address, tc.addr)
+		}
+
+		// Verify Extra field
+		if result.Extra != tc.extra {
+			t.Fatalf("invalid extra for %v, want: %d (0x%x) got: %d (0x%x)",
+				tc.addr, tc.extra, tc.extra, result.Extra, result.Extra)
+		}
+	}
+}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1025,6 +1025,7 @@ type OverrideAccount struct {
 	Balance   **hexutil.Big                `json:"balance"`
 	State     *map[common.Hash]common.Hash `json:"state"`
 	StateDiff *map[common.Hash]common.Hash `json:"stateDiff"`
+	Extra     *hexutil.Uint64              `json:"extra"`
 }
 
 // StateOverride is the collection of overridden accounts.
@@ -1039,6 +1040,10 @@ func (diff *StateOverride) Apply(state *state.StateDB) error {
 		// Override account nonce.
 		if account.Nonce != nil {
 			state.SetNonce(addr, uint64(*account.Nonce))
+		}
+		// Override account extra.
+		if account.Extra != nil {
+			state.SetExtra(addr, uint64(*account.Extra))
 		}
 		// Override account(contract) code.
 		if account.Code != nil {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -731,6 +731,7 @@ type AccountResult struct {
 	Nonce        hexutil.Uint64  `json:"nonce"`
 	StorageHash  common.Hash     `json:"storageHash"`
 	StorageProof []StorageResult `json:"storageProof"`
+	Extra        hexutil.Uint64  `json:"extra,omitempty"`
 }
 
 type StorageResult struct {
@@ -826,6 +827,7 @@ func (s *BlockChainAPI) GetProof(ctx context.Context, address common.Address, st
 		Nonce:        hexutil.Uint64(statedb.GetNonce(address)),
 		StorageHash:  storageRoot,
 		StorageProof: storageProof,
+		Extra:        hexutil.Uint64(statedb.GetExtra(address)),
 	}, statedb.Error()
 }
 

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -930,6 +930,22 @@ func TestCall(t *testing.T) {
 			},
 			want: "0x000000000000000000000000000000000000000000000000000000000000007b",
 		},
+		// State override with Extra field
+		{
+			blockNumber: rpc.LatestBlockNumber,
+			call: TransactionArgs{
+				From:  &randomAccounts[0].addr,
+				To:    &randomAccounts[1].addr,
+				Value: (*hexutil.Big)(big.NewInt(1000)),
+			},
+			overrides: StateOverride{
+				randomAccounts[0].addr: OverrideAccount{
+					Balance: newRPCBalance(new(big.Int).Mul(big.NewInt(1), big.NewInt(params.Ether))),
+					Extra:   func() *hexutil.Uint64 { v := hexutil.Uint64(12345); return &v }(),
+				},
+			},
+			want: "0x",
+		},
 		// Block overrides should work
 		{
 			blockNumber: rpc.LatestBlockNumber,

--- a/systemcontracts/test/coin_adapter_test.go
+++ b/systemcontracts/test/coin_adapter_test.go
@@ -167,10 +167,10 @@ func TestTransferLog(t *testing.T) {
 		transferEvents := findEvents("Transfer", receipt.Logs)
 		require.Equal(t, 2, len(transferEvents)) // mint, gas
 
-		eventMint := transferEvents[0]
-		require.Equal(t, minter.Address, eventMint["from"].(common.Address))
-		require.Equal(t, common.Address{}, eventMint["to"].(common.Address))
-		require.True(t, burnAmount.Cmp(eventMint["value"].(*big.Int)) == 0)
+		eventTransfer := transferEvents[0]
+		require.Equal(t, minter.Address, eventTransfer["from"].(common.Address))
+		require.Equal(t, common.Address{}, eventTransfer["to"].(common.Address))
+		require.True(t, burnAmount.Cmp(eventTransfer["value"].(*big.Int)) == 0)
 
 		checkGasFeeTransferEvent(transferEvents[1], minter.Address, receipt)
 	})

--- a/systemcontracts/test/coin_adapter_test.go
+++ b/systemcontracts/test/coin_adapter_test.go
@@ -61,12 +61,12 @@ func TestTransferLog(t *testing.T) {
 		require.NoError(t, err)
 
 		transferEvents := findEvents("Transfer", receipt.Logs)
-		require.Equal(t, 2, len(transferEvents)) // mint, gas
+		require.Equal(t, 2, len(transferEvents))
 
-		eventMint := transferEvents[0]
-		require.Equal(t, common.Address{}, eventMint["from"].(common.Address))
-		require.Equal(t, sender.Address, eventMint["to"].(common.Address))
-		require.True(t, mintAmount.Cmp(eventMint["value"].(*big.Int)) == 0)
+		eventTransfer := transferEvents[0]
+		require.Equal(t, common.Address{}, eventTransfer["from"].(common.Address))
+		require.Equal(t, sender.Address, eventTransfer["to"].(common.Address))
+		require.True(t, mintAmount.Cmp(eventTransfer["value"].(*big.Int)) == 0)
 
 		checkGasFeeTransferEvent(transferEvents[1], minter.Address, receipt)
 	})
@@ -76,12 +76,12 @@ func TestTransferLog(t *testing.T) {
 		require.NoError(t, err)
 
 		transferEvents := findEvents("Transfer", receipt.Logs)
-		require.Equal(t, 2, len(transferEvents)) // mint, gas
+		require.Equal(t, 2, len(transferEvents))
 
-		eventMint := transferEvents[0]
-		require.Equal(t, sender.Address, eventMint["from"].(common.Address))
-		require.Equal(t, recipient.Address, eventMint["to"].(common.Address))
-		require.True(t, amount.Cmp(eventMint["value"].(*big.Int)) == 0)
+		eventTransfer := transferEvents[0]
+		require.Equal(t, sender.Address, eventTransfer["from"].(common.Address))
+		require.Equal(t, recipient.Address, eventTransfer["to"].(common.Address))
+		require.True(t, amount.Cmp(eventTransfer["value"].(*big.Int)) == 0)
 
 		checkGasFeeTransferEvent(transferEvents[1], sender.Address, receipt)
 	})
@@ -91,7 +91,7 @@ func TestTransferLog(t *testing.T) {
 		require.NoError(t, err)
 
 		transferEvents := findEvents("Transfer", receipt.Logs)
-		require.Equal(t, 2, len(transferEvents)) // mint, gas
+		require.Equal(t, 2, len(transferEvents))
 
 		eventTransfer := transferEvents[0]
 		require.Equal(t, sender.Address, eventTransfer["from"].(common.Address))
@@ -106,7 +106,7 @@ func TestTransferLog(t *testing.T) {
 		require.NoError(t, err)
 
 		transferEvents := findEvents("Transfer", receipt.Logs)
-		require.Equal(t, 2, len(transferEvents)) // mint, gas
+		require.Equal(t, 2, len(transferEvents))
 
 		eventTransfer := transferEvents[0]
 		require.Equal(t, sender.Address, eventTransfer["from"].(common.Address))
@@ -143,7 +143,7 @@ func TestTransferLog(t *testing.T) {
 			require.NoError(t, err)
 
 			transferEvents := findEvents("Transfer", receipt.Logs)
-			require.Equal(t, 3, len(transferEvents)) // mint, gas
+			require.Equal(t, 3, len(transferEvents))
 
 			eventTxValue := transferEvents[0]
 			require.Equal(t, recipient.Address, eventTxValue["from"].(common.Address))
@@ -165,7 +165,7 @@ func TestTransferLog(t *testing.T) {
 		require.NoError(t, err)
 
 		transferEvents := findEvents("Transfer", receipt.Logs)
-		require.Equal(t, 2, len(transferEvents)) // mint, gas
+		require.Equal(t, 2, len(transferEvents))
 
 		eventTransfer := transferEvents[0]
 		require.Equal(t, minter.Address, eventTransfer["from"].(common.Address))
@@ -186,7 +186,7 @@ func TestTransferLog(t *testing.T) {
 			require.NoError(t, err)
 
 			transferEvents := findEvents("Transfer", receipt.Logs)
-			require.Equal(t, 2, len(transferEvents)) // mint, gas
+			require.Equal(t, 2, len(transferEvents))
 
 			eventTransfer := transferEvents[0]
 			require.Equal(t, sender.Address, eventTransfer["from"].(common.Address))
@@ -207,7 +207,7 @@ func TestTransferLog(t *testing.T) {
 			require.NoError(t, err)
 
 			transferEvents := findEvents("Transfer", receipt.Logs)
-			require.Equal(t, 2, len(transferEvents)) // mint, gas
+			require.Equal(t, 2, len(transferEvents))
 
 			eventTransfer := transferEvents[0]
 			require.Equal(t, sender.Address, eventTransfer["from"].(common.Address))

--- a/systemcontracts/test/coin_adapter_test.go
+++ b/systemcontracts/test/coin_adapter_test.go
@@ -174,6 +174,49 @@ func TestTransferLog(t *testing.T) {
 
 		checkGasFeeTransferEvent(transferEvents[1], minter.Address, receipt)
 	})
+
+	t.Run("fee delegation", func(t *testing.T) {
+		transferAmount := new(big.Int).Div(amount, common.Big2)
+		// native transfer
+		{
+			baseTx, err := CreateDynamicTx(g.backend.Client(), NewTxOptsWithValue(t, sender, transferAmount), &(recipient.Address), nil)
+			require.NoError(t, err)
+
+			receipt, err := g.ExpectedOk(SendFeeDelegateTx(g.backend.Client(), minter, baseTx))
+			require.NoError(t, err)
+
+			transferEvents := findEvents("Transfer", receipt.Logs)
+			require.Equal(t, 2, len(transferEvents)) // mint, gas
+
+			eventTransfer := transferEvents[0]
+			require.Equal(t, sender.Address, eventTransfer["from"].(common.Address))
+			require.Equal(t, recipient.Address, eventTransfer["to"].(common.Address))
+			require.True(t, transferAmount.Cmp(eventTransfer["value"].(*big.Int)) == 0)
+
+			checkGasFeeTransferEvent(transferEvents[1], minter.Address, receipt)
+		}
+
+		// transfer by NativeCoinAdapter
+		{
+			opts := NewTxOpts(t, sender)
+			opts.NoSend = true
+			baseTx, err := g.coinAdapter.Transact(opts, "transfer", recipient.Address, transferAmount)
+			require.NoError(t, err)
+
+			receipt, err := g.ExpectedOk(SendFeeDelegateTx(g.backend.Client(), minter, baseTx))
+			require.NoError(t, err)
+
+			transferEvents := findEvents("Transfer", receipt.Logs)
+			require.Equal(t, 2, len(transferEvents)) // mint, gas
+
+			eventTransfer := transferEvents[0]
+			require.Equal(t, sender.Address, eventTransfer["from"].(common.Address))
+			require.Equal(t, recipient.Address, eventTransfer["to"].(common.Address))
+			require.True(t, transferAmount.Cmp(eventTransfer["value"].(*big.Int)) == 0)
+
+			checkGasFeeTransferEvent(transferEvents[1], minter.Address, receipt)
+		}
+	})
 }
 
 func TestNativeCoinAdapter(t *testing.T) {

--- a/systemcontracts/test/contracts_wbft.go
+++ b/systemcontracts/test/contracts_wbft.go
@@ -186,6 +186,7 @@ func NewGovWBFT(t *testing.T, alloc types.GenesisAlloc, validatorOption, adapter
 	g := &GovWBFT{
 		owner: owner,
 		backend: simulated.NewWBFTBackend(alloc, func(nodeConf *node.Config, ethConf *ethconfig.Config) {
+			ethConf.Genesis.Config.ApplepieBlock = big.NewInt(0)
 			anzeonConfig := ethConf.Genesis.Config.Anzeon
 			defaultBlockPeriod = time.Duration(anzeonConfig.WBFT.BlockPeriodSeconds) * time.Second
 

--- a/systemcontracts/test/utils.go
+++ b/systemcontracts/test/utils.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient/simulated"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -151,6 +152,35 @@ func CreateDynamicTx(backend IBackend, opts *bind.TransactOpts, to *common.Addre
 	}
 
 	return opts.Signer(opts.From, types.NewTx(baseTx))
+}
+
+func SendFeeDelegateTx(backend IBackend, feePayer *EOA, baseTx *types.Transaction) (*types.Transaction, error) {
+	txData, err := baseTx.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+
+	var senderTx types.DynamicFeeTx
+	// First byte is tx.Type; exclude when decoding
+	rlp.DecodeBytes(txData[1:], &senderTx)
+
+	feeDelegateTx := types.NewTx(&types.FeeDelegateDynamicFeeTx{
+		SenderTx: senderTx,
+		FeePayer: &feePayer.Address,
+	})
+
+	signer := types.NewFeeDelegateSigner(params.TestWBFTChainConfig.ChainID)
+	signature, err := crypto.Sign(signer.Hash(feeDelegateTx).Bytes(), feePayer.PrivateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := feeDelegateTx.WithSignature(signer, signature)
+	if err != nil {
+		return nil, err
+	}
+
+	return tx, backend.SendTransaction(context.Background(), tx)
 }
 
 func TransferCoin(backend IBackend, opts *bind.TransactOpts, value *big.Int, to *common.Address) (*types.Transaction, error) {


### PR DESCRIPTION
### Summary
This PR ensures the `Extra` field, which exists in `StateAccount`, is correctly included in the `eth_getProof` API output, `StateOverride` functionality, and `prestate` tracer. Previously, this field was missing from the result or unsupported.

### Changes
- Updated `AccountResult` struct to include the `Extra` field
- Modified `eth_getProof` implementation to populate the `Extra` field
- Updated `OverrideAccount` struct and `Apply` method to support setting the `Extra` field
- Updated `account` struct and logic in `prestate` tracer to capture and report the `Extra` field
- Added `GetExtra` method to `StateDB` interface

### Additional
- Added test cases for fee-delegated transactions to verify transfer logs
- Added test cases for `StateOverride` and `prestate` tracer to verify `Extra` field handling