### PR TITLE
refactor: remove unimplemented 'admin_wemixInfo' property

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -207,10 +207,7 @@ web3._extend({
 			name: 'datadir',
 			getter: 'admin_datadir'
 		}),
-		new web3._extend.Property({
-			name: 'wemixInfo',
-			getter: 'admin_wemixInfo'
-		}),
+
 	]
 });
 `


### PR DESCRIPTION
The 'admin_wemixInfo' property in AdminJs extension is removed because there is no underlying implementation.