### PR TITLE
fix: optimize Anzeon gas tip cap handling

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -578,7 +578,6 @@ func (pool *LegacyPool) Pending(filter txpool.PendingFilter) map[common.Address]
 	if filter.MinTip != nil {
 		minTipBig = filter.MinTip.ToBig()
 	}
-	pool.anzeonTipEnv.SetCurrentBlock(filter.NewHeader) // filter.NewHeader can be nil, but it doesn't matter
 	if filter.BaseFee != nil {
 		pool.anzeonTipEnv.SetBaseFee(filter.BaseFee.ToBig())
 	}

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -343,6 +343,9 @@ func (pool *LegacyPool) Init(gasTip uint64, head *types.Header, reserver txpool.
 	pool.currentState = statedb
 	pool.pendingNonces = newNoncer(statedb)
 	pool.anzeonTipEnv.SetCurrentBlock(head)
+	if pool.chainconfig.IsLondon(new(big.Int).Add(head.Number, big.NewInt(1))) {
+		pool.anzeonTipEnv.SetBaseFee(eip1559.CalcBaseFee(pool.chainconfig, head))
+	}
 
 	// Start the reorg loop early, so it can handle requests generated during
 	// journal loading.
@@ -578,6 +581,7 @@ func (pool *LegacyPool) Pending(filter txpool.PendingFilter) map[common.Address]
 	if filter.MinTip != nil {
 		minTipBig = filter.MinTip.ToBig()
 	}
+	pool.anzeonTipEnv.SetCurrentBlock(filter.Header) // filter.NewHeader can be nil, but it doesn't matter
 	if filter.BaseFee != nil {
 		pool.anzeonTipEnv.SetBaseFee(filter.BaseFee.ToBig())
 	}

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -688,6 +688,7 @@ func (pool *LegacyPool) validateTx(tx *types.Transaction, local bool) error {
 			}
 			return nil
 		},
+		AnzeonTipEnv: pool.anzeonTipEnv, // Enable caching of Anzeon tip cap during validation
 	}
 	if err := txpool.ValidateTransactionWithState(tx, pool.signer, opts); err != nil {
 		return err

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -68,11 +68,14 @@ type testBlockChain struct {
 	gasLimit      atomic.Uint64
 	statedb       *state.StateDB
 	chainHeadFeed *event.Feed
+	baseFee       *big.Int
 }
 
 func newTestBlockChain(config *params.ChainConfig, gasLimit uint64, statedb *state.StateDB, chainHeadFeed *event.Feed) *testBlockChain {
 	bc := testBlockChain{config: config, statedb: statedb, chainHeadFeed: new(event.Feed)}
 	bc.gasLimit.Store(gasLimit)
+	bc.baseFee = new(big.Int).SetUint64(params.InitialBaseFee)
+
 	return &bc
 }
 
@@ -84,6 +87,7 @@ func (bc *testBlockChain) CurrentBlock() *types.Header {
 	return &types.Header{
 		Number:   new(big.Int),
 		GasLimit: bc.gasLimit.Load(),
+		BaseFee:  bc.baseFee,
 	}
 }
 

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -135,6 +135,11 @@ func dynamicFeeTx(nonce uint64, gaslimit uint64, gasFee *big.Int, tip *big.Int, 
 	return tx
 }
 
+// gwei converts a gwei value to wei (big.Int)
+func gwei(n int64) *big.Int {
+	return new(big.Int).Mul(big.NewInt(n), big.NewInt(params.GWei))
+}
+
 type unsignedAuth struct {
 	nonce uint64
 	key   *ecdsa.PrivateKey
@@ -2007,6 +2012,7 @@ func TestStableUnderpricing(t *testing.T) {
 //
 // Note, local transactions are never allowed to be dropped.
 func TestUnderpricingDynamicFee(t *testing.T) {
+	// Enable verbose logging for this test
 	t.Parallel()
 
 	pool, _ := setupPoolWithConfig(eip1559Config)
@@ -2024,17 +2030,17 @@ func TestUnderpricingDynamicFee(t *testing.T) {
 	keys := make([]*ecdsa.PrivateKey, 4)
 	for i := 0; i < len(keys); i++ {
 		keys[i], _ = crypto.GenerateKey()
-		testAddBalance(pool, crypto.PubkeyToAddress(keys[i].PublicKey), big.NewInt(1000000))
+		testAddBalance(pool, crypto.PubkeyToAddress(keys[i].PublicKey), new(big.Int).Mul(big.NewInt(1), big.NewInt(params.Ether)))
 	}
 
 	// Generate and queue a batch of transactions, both pending and queued
 	txs := types.Transactions{}
 
-	txs = append(txs, dynamicFeeTx(0, 100000, big.NewInt(3), big.NewInt(2), keys[0]))
-	txs = append(txs, pricedTransaction(1, 100000, big.NewInt(2), keys[0]))
-	txs = append(txs, dynamicFeeTx(1, 100000, big.NewInt(2), big.NewInt(1), keys[1]))
+	txs = append(txs, dynamicFeeTx(0, 100000, gwei(3), gwei(2), keys[0]))
+	txs = append(txs, pricedTransaction(1, 100000, gwei(2), keys[0]))
+	txs = append(txs, dynamicFeeTx(1, 100000, gwei(2), gwei(1), keys[1]))
 
-	ltx := dynamicFeeTx(0, 100000, big.NewInt(2), big.NewInt(1), keys[2])
+	ltx := dynamicFeeTx(0, 100000, gwei(2), gwei(1), keys[2])
 
 	// Import the batch and that both pending and queued transactions match up
 	pool.addRemotes(txs) // Pend K0:0, K0:1; Que K1:1
@@ -2055,22 +2061,22 @@ func TestUnderpricingDynamicFee(t *testing.T) {
 	}
 
 	// Ensure that adding an underpriced transaction fails
-	tx := dynamicFeeTx(0, 100000, big.NewInt(2), big.NewInt(1), keys[1])
+	tx := dynamicFeeTx(0, 100000, gwei(2), gwei(1), keys[1])
 	if err := pool.addRemote(tx); !errors.Is(err, txpool.ErrUnderpriced) { // Pend K0:0, K0:1, K2:0; Que K1:1
 		t.Fatalf("adding underpriced pending transaction error mismatch: have %v, want %v", err, txpool.ErrUnderpriced)
 	}
 
 	// Ensure that adding high priced transactions drops cheap ones, but not own
-	tx = pricedTransaction(0, 100000, big.NewInt(2), keys[1])
+	tx = pricedTransaction(0, 100000, gwei(2), keys[1])
 	if err := pool.addRemote(tx); err != nil { // +K1:0, -K1:1 => Pend K0:0, K0:1, K1:0, K2:0; Que -
 		t.Fatalf("failed to add well priced transaction: %v", err)
 	}
 
-	tx = pricedTransaction(1, 100000, big.NewInt(3), keys[1])
+	tx = pricedTransaction(1, 100000, gwei(3), keys[1])
 	if err := pool.addRemoteSync(tx); err != nil { // +K1:2, -K0:1 => Pend K0:0 K1:0, K2:0; Que K1:2
 		t.Fatalf("failed to add well priced transaction: %v", err)
 	}
-	tx = dynamicFeeTx(2, 100000, big.NewInt(4), big.NewInt(1), keys[1])
+	tx = dynamicFeeTx(2, 100000, gwei(4), gwei(3), keys[1])
 	if err := pool.addRemoteSync(tx); err != nil { // +K1:3, -K1:0 => Pend K0:0 K2:0; Que K1:2 K1:3
 		t.Fatalf("failed to add well priced transaction: %v", err)
 	}

--- a/core/txpool/legacypool/list_test.go
+++ b/core/txpool/legacypool/list_test.go
@@ -129,6 +129,10 @@ func (atEnv *testAnzeonTipEnv) GetBaseFee() *big.Int {
 }
 
 func (atEnv *testAnzeonTipEnv) GetAnzeonTipCap(tx *types.Transaction) *big.Int {
+	if !atEnv.IsAnzeon() {
+		return tx.GasTipCap()
+	}
+
 	if ok, is := atEnv.isAuthorized[tx.Hash()]; !ok || !is {
 		if atEnv.headerTip == nil {
 			return tx.GasTipCap()
@@ -144,6 +148,10 @@ func (atEnv *testAnzeonTipEnv) SetCurrentBlock(header *types.Header) {
 
 func (atEnv *testAnzeonTipEnv) SetBaseFee(baseFee *big.Int) {
 	atEnv.baseFee = baseFee
+}
+
+func (atEnv *testAnzeonTipEnv) IsAnzeon() bool {
+	return true
 }
 
 func (atEnv *testAnzeonTipEnv) SetHeaderGasTip(headerGasTip *big.Int) {

--- a/core/txpool/subpool.go
+++ b/core/txpool/subpool.go
@@ -73,10 +73,10 @@ type LazyResolver interface {
 // a very specific call site in mind and each one can be evaluated very cheaply
 // by the pool implementations. Only add new ones that satisfy those constraints.
 type PendingFilter struct {
-	MinTip    *uint256.Int  // Minimum miner tip required to include a transaction
-	BaseFee   *uint256.Int  // Minimum 1559 basefee needed to include a transaction
-	BlobFee   *uint256.Int  // Minimum 4844 blobfee needed to include a blob transaction
-	NewHeader *types.Header // New head header to evaluate tx against (for basefee calculations)
+	MinTip  *uint256.Int  // Minimum miner tip required to include a transaction
+	BaseFee *uint256.Int  // Minimum 1559 basefee needed to include a transaction
+	BlobFee *uint256.Int  // Minimum 4844 blobfee needed to include a blob transaction
+	Header  *types.Header // New head header to evaluate tx against (for basefee calculations)
 
 	OnlyPlainTxs bool // Return only plain EVM transactions (peer-join announces, block space filling)
 	OnlyBlobTxs  bool // Return only blob transactions (block blob-space filling)

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -217,6 +217,10 @@ type ValidationOptionsWithState struct {
 	// ExistingCost is a mandatory callback to retrieve an already pooled
 	// transaction's cost with the given nonce to check for overdrafts.
 	ExistingCost func(addr common.Address, nonce uint64) *big.Int
+
+	// AnzeonTipEnv is an optional environment for computing and caching
+	// the Anzeon gas tip cap during validation to avoid repeated state queries during reheap.
+	AnzeonTipEnv types.AnzeonGasTipEnv
 }
 
 // ValidateTransactionWithState is a helper method to check whether a transaction
@@ -317,5 +321,13 @@ func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, op
 			}
 		}
 	*/
+
+	// Cache the Anzeon tip cap to avoid repeated state queries during reheap
+	// Only cache if not already set (to preserve original value during reinject)
+	if opts.AnzeonTipEnv != nil && tx.GetAnzeonTipCap() == nil {
+		tipCap := opts.AnzeonTipEnv.GetAnzeonTipCap(tx)
+		tx.SetAnzeonTipCap(tipCap)
+	}
+
 	return nil
 }

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -356,6 +356,10 @@ func (atEnv *anzeonTipEnv) GetBaseFee() *big.Int {
 }
 
 func (atEnv *anzeonTipEnv) GetAnzeonTipCap(tx *Transaction) *big.Int {
+	if !atEnv.IsAnzeon() {
+		return tx.GasTipCap()
+	}
+
 	from, err := Sender(atEnv.signer, tx)
 	if err == nil && atEnv.stateReader != nil && !atEnv.stateReader.IsAuthorized(from) && atEnv.headerTip != nil {
 		// In Anzeon, normal account gas tip cap is determined by the block header gas tip
@@ -368,6 +372,11 @@ func (atEnv *anzeonTipEnv) SetCurrentBlock(header *Header) {
 }
 
 func (atEnv *anzeonTipEnv) SetBaseFee(baseFee *big.Int) {
+}
+
+// IsValid returns true as this environment is always valid when instantiated.
+func (atEnv *anzeonTipEnv) IsAnzeon() bool {
+	return true
 }
 
 // DeriveFields fills the receipts with their computed fields based on consensus

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -71,6 +71,9 @@ type Transaction struct {
 
 	// WEMIX fee delegation
 	feePayer atomic.Value
+
+	// Anzeon gas tip cap cache (set during pool validation, used during reheap)
+	anzeonTipCap atomic.Value
 }
 
 // NewTx creates a new transaction.
@@ -390,7 +393,12 @@ func (tx *Transaction) EffectiveGasTip(anzeonTipEnv AnzeonGasTipEnv) (*big.Int, 
 	if gasFeeCap.Cmp(anzeonTipEnv.GetBaseFee()) == -1 {
 		err = ErrGasFeeCapTooLow
 	}
-	return math.BigMin(anzeonTipEnv.GetAnzeonTipCap(tx), gasFeeCap.Sub(gasFeeCap, anzeonTipEnv.GetBaseFee())), err
+	// Use cached tipCap if available, otherwise fetch from anzeonTipEnv
+	tipCap := tx.GetAnzeonTipCap()
+	if tipCap == nil {
+		tipCap = anzeonTipEnv.GetAnzeonTipCap(tx)
+	}
+	return math.BigMin(tipCap, new(big.Int).Sub(gasFeeCap, anzeonTipEnv.GetBaseFee())), err
 }
 
 // EffectiveGasTipValue is identical to EffectiveGasTip, but does not return an
@@ -398,6 +406,22 @@ func (tx *Transaction) EffectiveGasTip(anzeonTipEnv AnzeonGasTipEnv) (*big.Int, 
 func (tx *Transaction) EffectiveGasTipValue(anzeonTipEnv AnzeonGasTipEnv) *big.Int {
 	effectiveTip, _ := tx.EffectiveGasTip(anzeonTipEnv)
 	return effectiveTip
+}
+
+// SetAnzeonTipCap caches the Anzeon tip cap for this transaction.
+// This is set during pool validation to avoid repeated state queries during reheap.
+func (tx *Transaction) SetAnzeonTipCap(tipCap *big.Int) {
+	if tipCap != nil {
+		tx.anzeonTipCap.Store(new(big.Int).Set(tipCap))
+	}
+}
+
+// GetAnzeonTipCap returns the cached Anzeon tip cap, or nil if not cached.
+func (tx *Transaction) GetAnzeonTipCap() *big.Int {
+	if cached := tx.anzeonTipCap.Load(); cached != nil {
+		return cached.(*big.Int)
+	}
+	return nil
 }
 
 // EffectiveGasTipCmp compares the effective gasTipCap of two transactions assuming the given base fee.

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -54,6 +54,7 @@ const (
 )
 
 type AnzeonGasTipEnv interface {
+	IsAnzeon() bool
 	GetBaseFee() *big.Int
 	GetAnzeonTipCap(tx *Transaction) *big.Int
 	SetCurrentBlock(header *Header)

--- a/eth/gasprice/anzeon.go
+++ b/eth/gasprice/anzeon.go
@@ -32,6 +32,7 @@ type AnzeonTipEnv struct {
 	config       *params.ChainConfig
 	stateAt      func(common.Hash) (*state.StateDB, error)
 	currentBlock *types.Header
+	currentState *state.StateDB
 	baseFee      *big.Int
 	signer       types.Signer
 }
@@ -50,8 +51,11 @@ func (env *AnzeonTipEnv) SetCurrentBlock(header *types.Header) {
 	if header == nil {
 		return
 	}
-	env.currentBlock = header
-	env.signer = types.MakeSigner(env.config, header.Number, header.Time)
+	if env.currentBlock == nil || env.currentBlock.Root != header.Root {
+		env.currentBlock = header
+		env.currentState, _ = env.stateAt(header.Root)
+		env.signer = types.MakeSigner(env.config, header.Number, header.Time)
+	}
 }
 
 // SetBaseFee updates the base fee for gas price calculations.
@@ -87,13 +91,17 @@ func (env *AnzeonTipEnv) GetAnzeonTipCap(tx *types.Transaction) *big.Int {
 	}
 
 	// Check if sender is authorized by querying state
-	if env.stateAt != nil && env.currentBlock.Root != (common.Hash{}) {
-		stateDB, err := env.stateAt(env.currentBlock.Root)
-		if err == nil && stateDB != nil {
-			// For unauthorized accounts, use block header's gas tip
-			if !stateDB.IsAuthorized(from) && env.currentBlock.GasTip() != nil {
-				return env.currentBlock.GasTip()
-			}
+	// First try to use cached state, then fall back to stateAt
+	var stateDB *state.StateDB
+	if env.currentState != nil {
+		stateDB = env.currentState
+	} else if env.stateAt != nil && env.currentBlock.Root != (common.Hash{}) {
+		stateDB, _ = env.stateAt(env.currentBlock.Root)
+	}
+	if stateDB != nil {
+		// For unauthorized accounts, use block header's gas tip
+		if !stateDB.IsAuthorized(from) && env.currentBlock.GasTip() != nil {
+			return env.currentBlock.GasTip()
 		}
 	}
 

--- a/eth/gasprice/anzeon.go
+++ b/eth/gasprice/anzeon.go
@@ -67,6 +67,11 @@ func (env *AnzeonTipEnv) SetBaseFee(baseFee *big.Int) {
 	env.baseFee = baseFee
 }
 
+// IsValid returns true if Anzeon is enabled and the environment is properly initialized.
+func (env *AnzeonTipEnv) IsAnzeon() bool {
+	return env.config != nil && env.config.AnzeonEnabled()
+}
+
 // GetBaseFee returns the current base fee.
 // It returns the explicitly set base fee, or falls back to the current block's base fee.
 func (env *AnzeonTipEnv) GetBaseFee() *big.Int {
@@ -84,7 +89,7 @@ func (env *AnzeonTipEnv) GetBaseFee() *big.Int {
 // For authorized accounts (validators/minters), it returns the transaction's original gas tip cap.
 func (env *AnzeonTipEnv) GetAnzeonTipCap(tx *types.Transaction) *big.Int {
 	// If environment is not fully initialized, return transaction's gas tip cap
-	if env.signer == nil || env.currentBlock == nil {
+	if !env.IsAnzeon() || env.signer == nil || env.currentBlock == nil {
 		return tx.GasTipCap()
 	}
 

--- a/eth/gasprice/anzeon.go
+++ b/eth/gasprice/anzeon.go
@@ -53,7 +53,11 @@ func (env *AnzeonTipEnv) SetCurrentBlock(header *types.Header) {
 	}
 	if env.currentBlock == nil || env.currentBlock.Root != header.Root {
 		env.currentBlock = header
-		env.currentState = nil
+		if header.Root != (common.Hash{}) {
+			env.currentState, _ = env.stateAt(header.Root)
+		} else {
+			env.currentState = nil
+		}
 		env.signer = types.MakeSigner(env.config, header.Number, header.Time)
 	}
 }

--- a/eth/gasprice/anzeon.go
+++ b/eth/gasprice/anzeon.go
@@ -53,7 +53,7 @@ func (env *AnzeonTipEnv) SetCurrentBlock(header *types.Header) {
 	}
 	if env.currentBlock == nil || env.currentBlock.Root != header.Root {
 		env.currentBlock = header
-		env.currentState, _ = env.stateAt(header.Root)
+		env.currentState = nil
 		env.signer = types.MakeSigner(env.config, header.Number, header.Time)
 	}
 }
@@ -92,17 +92,18 @@ func (env *AnzeonTipEnv) GetAnzeonTipCap(tx *types.Transaction) *big.Int {
 
 	// Check if sender is authorized by querying state
 	// First try to use cached state, then fall back to stateAt
-	var stateDB *state.StateDB
-	if env.currentState != nil {
-		stateDB = env.currentState
-	} else if env.stateAt != nil && env.currentBlock.Root != (common.Hash{}) {
-		stateDB, _ = env.stateAt(env.currentBlock.Root)
+	// Lazy load state if not cached
+	if env.currentState == nil &&
+		env.stateAt != nil &&
+		env.currentBlock.Root != (common.Hash{}) {
+		env.currentState, _ = env.stateAt(env.currentBlock.Root)
 	}
-	if stateDB != nil {
-		// For unauthorized accounts, use block header's gas tip
-		if !stateDB.IsAuthorized(from) && env.currentBlock.GasTip() != nil {
-			return env.currentBlock.GasTip()
-		}
+
+	// For unauthorized accounts, use block header's gas tip
+	if env.currentState != nil &&
+		!env.currentState.IsAuthorized(from) &&
+		env.currentBlock.GasTip() != nil {
+		return env.currentBlock.GasTip()
 	}
 
 	// For authorized accounts or if state is unavailable, use transaction's gas tip cap

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -69,6 +69,7 @@ type testBlockChain struct {
 	config        *params.ChainConfig
 	statedb       *state.StateDB
 	gasLimit      uint64
+	baseFee       *big.Int
 	chainHeadFeed *event.Feed
 }
 
@@ -80,6 +81,7 @@ func (bc *testBlockChain) CurrentBlock() *types.Header {
 	return &types.Header{
 		Number:   new(big.Int),
 		GasLimit: bc.gasLimit,
+		BaseFee:  bc.baseFee,
 	}
 }
 
@@ -315,7 +317,8 @@ func createMiner(t *testing.T) (*Miner, *event.TypeMux, func(skipMiner bool)) {
 		t.Fatalf("can't create new chain %v", err)
 	}
 	statedb, _ := state.New(bc.Genesis().Root(), bc.StateCache(), nil)
-	blockchain := &testBlockChain{bc.Genesis().Root(), chainConfig, statedb, 10000000, new(event.Feed)}
+	genesisBaseFee := bc.Genesis().Header().BaseFee
+	blockchain := &testBlockChain{bc.Genesis().Root(), chainConfig, statedb, 10000000, genesisBaseFee, new(event.Feed)}
 
 	pool := legacypool.New(testTxPoolConfig, blockchain)
 	txpool, _ := txpool.New(testTxPoolConfig.PriceLimit, blockchain, []txpool.SubPool{pool})

--- a/miner/ordering_test.go
+++ b/miner/ordering_test.go
@@ -104,6 +104,10 @@ func (natEnv *noAnzeonTIpEnv) GetAnzeonTipCap(tx *types.Transaction) *big.Int {
 func (natEnv *noAnzeonTIpEnv) SetCurrentBlock(header *types.Header) {
 }
 
+func (natEnv *noAnzeonTIpEnv) IsAnzeon() bool {
+	return false
+}
+
 func (natEnv *noAnzeonTIpEnv) SetBaseFee(baseFee *big.Int) {
 	natEnv.baseFee = baseFee
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1236,7 +1236,7 @@ func (w *worker) fillTransactions(interrupt *atomic.Int32, env *environment) err
 	filter := txpool.PendingFilter{
 		MinTip: tip,
 	}
-	filter.NewHeader = env.header
+	filter.Header = w.chain.CurrentBlock()
 	if env.header.BaseFee != nil {
 		filter.BaseFee = uint256.MustFromBig(env.header.BaseFee)
 	}


### PR DESCRIPTION
## Summary

This PR improves the **performance and stability of Anzeon gas tip cap calculation**.  
It reduces redundant `StateDB` accesses and addresses duplicated computation and state consistency issues during pending handling and txpool reheap.

---

## Key Changes

### 1. StateDB Caching Optimization (`504ad0736`)

- Added a `currentState` field to `AnzeonTipEnv` to cache the `StateDB`
- Load state only when the block root changes
- Prefer the cached state during gas tip cap calculation, with fallback only when needed

**Impact**
- Eliminates repeated `StateDB` lookups within the same block context
- Reduces state access cost during gas tip cap calculation

---

### 2. State and BaseFee Handling Improvements (`14fbf0d5d`)

- Load state only when the header root is valid
- Initialize `baseFee` during `Init()` to support early pending calls
- Pass the chain head to the pending filter to ensure state loading consistency
- Rename `PendingFilter.NewHeader` to `Header` for clearer semantics

**Impact**
- Prevents invalid state access during early pending stages
- Improves consistency and stability of state and baseFee handling

---

### 3. Anzeon Tip Cap Caching for txpool Reheap Optimization (`0c78e44e1`)

- Cache Anzeon gas tip cap at the transaction level
- Use `atomic.Value` for caching, allowing safe reuse during txpool reheap and reordering

**Impact**
- Removes duplicated tip cap computation during txpool reheap
- Reduces txpool reconstruction cost and improves processing efficiency

---

### 4. Anzeon Activation Guard (`4a8f551dd`)

- Add an `IsAnzeon()` guard to `AnzeonGasTipEnv`
- Apply header-based tip calculation only when Anzeon is enabled

**Impact**
- Prevents unintended behavior when Anzeon is disabled
- Improves safety of gas tip calculation logic

---

## Overall Impact

- **Reduced StateDB access cost**
- **Lower txpool reheap overhead**
- **Improved pending handling stability and state consistency**

---

## Notes

- Some commits were cherry-picked from an existing branch.