### PR TITLE
fix: normalize comma-separated config strings

### DIFF
--- a/consensus/wbft/config.go
+++ b/consensus/wbft/config.go
@@ -124,7 +124,7 @@ var DefaultConfig = &Config{
 func (c *Config) GetSystemContracts(blockNumber *big.Int, chainConfig *params.ChainConfig) params.SystemContracts {
 	gc := params.SystemContracts{}
 
-	if c.SystemContractUpgrades != nil && len(c.SystemContractUpgrades) > 0 {
+	if len(c.SystemContractUpgrades) > 0 {
 		c.getSystemContractsValue(blockNumber, func(upgrade params.Upgrade) {
 			if upgrade.GovValidator != nil {
 				gc.GovValidator = upgrade.GovValidator

--- a/systemcontracts/coin_adapter.go
+++ b/systemcontracts/coin_adapter.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/big"
 	"strconv"
-	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -48,10 +47,10 @@ func initializeCoinAdapter(coinAdapterAddress common.Address, param map[string]s
 
 	// SLOT_COIN_ADAPTER_MINTERS, SLOT_COIN_ADAPTER_MINTER_ALLOWED
 	if mintersStr, ok := param[COIN_ADAPTER_PARAM_MINTERS]; ok && len(mintersStr) > 0 {
-		minters := strings.Split(mintersStr, ",")
+		minters := splitAndTrim(mintersStr, ",")
 		minterAllowedAmounts := make([]*big.Int, len(minters))
 		if minterAllowedStr, ok := param[COIN_ADAPTER_PARAM_MINTER_ALLOWED]; ok && len(minterAllowedStr) > 0 {
-			minterAllowed := strings.Split(minterAllowedStr, ",")
+			minterAllowed := splitAndTrim(minterAllowedStr, ",")
 			if len(minters) != len(minterAllowed) {
 				return nil, fmt.Errorf("`systemContracts.nativeCoinAdapter.params`: the number of minters and minterAllowedAmounts must be the same")
 			}

--- a/systemcontracts/gov_base.go
+++ b/systemcontracts/gov_base.go
@@ -65,6 +65,17 @@ const (
 	SLOT_GOV_BASE_maxActiveProposalsPerMember = "0xc"
 )
 
+func splitAndTrim(s, sep string) (ret []string) {
+	l := strings.Split(s, sep)
+	for _, r := range l {
+		r = strings.TrimSpace(r)
+		if len(r) > 0 {
+			ret = append(ret, r)
+		}
+	}
+	return ret
+}
+
 type Member struct {
 	IsActive bool
 	JoinedAt uint32
@@ -161,7 +172,7 @@ func initializeBase(govBaseAddress common.Address, param map[string]string) ([]p
 	}
 
 	if membersStr, ok := param[GOV_BASE_PARAM_MEMBERS]; ok {
-		memberAddresses := strings.Split(membersStr, ",")
+		memberAddresses := splitAndTrim(membersStr, ",")
 
 		// Pre-validate and deduplicate members
 		uniqueMembers := make([]common.Address, 0)

--- a/systemcontracts/gov_council.go
+++ b/systemcontracts/gov_council.go
@@ -68,7 +68,7 @@ func initializeGovCouncil(govCouncilAddress common.Address, param map[string]str
 
 	// Initialize blacklist if provided
 	if blacklistStr, ok := param[GOV_COUNCIL_PARAM_BLACKLIST]; ok && blacklistStr != "" {
-		blacklistAddresses := strings.Split(blacklistStr, ",")
+		blacklistAddresses := splitAndTrim(blacklistStr, ",")
 		blacklistParams, err := initializeAddressSet(
 			govCouncilAddress,
 			common.HexToHash(SLOT_GOV_COUNCIL_currentBlacklist_values),
@@ -84,7 +84,7 @@ func initializeGovCouncil(govCouncilAddress common.Address, param map[string]str
 
 	// Initialize authorized accounts if provided
 	if authorizedAccountsStr, ok := param[GOV_COUNCIL_PARAM_AUTHORIZED_ACCOUNTS]; ok && authorizedAccountsStr != "" {
-		authorizedAccountAddresses := strings.Split(authorizedAccountsStr, ",")
+		authorizedAccountAddresses := splitAndTrim(authorizedAccountsStr, ",")
 		authorizedAccountParams, err := initializeAddressSet(
 			govCouncilAddress,
 			common.HexToHash(SLOT_GOV_COUNCIL_currentAuthorizedAccounts_values),

--- a/systemcontracts/gov_master_minter.go
+++ b/systemcontracts/gov_master_minter.go
@@ -80,7 +80,7 @@ func initializeMasterMinter(govMasterMinterAddress common.Address, param map[str
 
 	// Initialize minters (comma-separated addresses)
 	if mintersStr, ok := param[GOV_MASTER_MINTER_PARAM_MINTERS]; ok {
-		minterAddressStrs := strings.Split(mintersStr, ",")
+		minterAddressStrs := splitAndTrim(mintersStr, ",")
 		if len(minterAddressStrs) == 0 {
 			return nil, fmt.Errorf("`systemContracts.govMasterMinter.params.minters`: no addresses provided")
 		}

--- a/systemcontracts/gov_validator.go
+++ b/systemcontracts/gov_validator.go
@@ -20,7 +20,6 @@ package systemcontracts
 import (
 	"fmt"
 	"math/big"
-	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
@@ -89,9 +88,9 @@ func initializeValidator(govValidatorAddress common.Address, param map[string]st
 			return nil, fmt.Errorf("`systemContracts.govValidator.params`: missing parameter: %s", GOV_VALIDATOR_PARAM_BLS_KEYS)
 		}
 
-		memberAddresses := strings.Split(param[GOV_BASE_PARAM_MEMBERS], ",")
-		valAddresses := strings.Split(valStr, ",")
-		blsKeyStrings := strings.Split(param[GOV_VALIDATOR_PARAM_BLS_KEYS], ",")
+		memberAddresses := splitAndTrim(param[GOV_BASE_PARAM_MEMBERS], ",")
+		valAddresses := splitAndTrim(valStr, ",")
+		blsKeyStrings := splitAndTrim(param[GOV_VALIDATOR_PARAM_BLS_KEYS], ",")
 		if len(memberAddresses) != len(valAddresses) {
 			return nil, fmt.Errorf("`systemContracts.govValidator.params`: the number of members and validators must be the same")
 		}


### PR DESCRIPTION
## Description

### Summary
System contract initialization now parses comma-separated config strings (members, validators, blsPublicKeys, blacklist, authorizedAccounts, minters, minterAllowed, etc.) in a **normalized** way:
- Split by the delimiter
- Trim whitespace for each item
- Drop empty entries
This ensures that genesis alloc (and therefore `hashAlloc` / state root) is **consistent for the same logical configuration**, regardless of formatting differences such as `"a, b"` vs `"a,b"`.

---

### Background
- The state root is computed only during `hashAlloc`.
- For the same `(address, account)` set, the trie yields the same root regardless of insertion order.
- However, the root can differ if the alloc passed into `hashAlloc` actually differs.
- One source of this discrepancy was inconsistent parsing of comma-separated config strings, especially when whitespace was present.
- As a result, logically identical configs could produce different genesis allocs and roots.

---

### Changes
- **gov_base.go**
  - Added `splitAndTrim(s, sep string) []string` utility (split by `sep`, trim each element, omit empty entries)
  - Applied when building `memberAddresses` from `membersStr`
- **gov_validator.go**
  - Build `memberAddresses`, `valAddresses`, and `blsKeyStrings` using `splitAndTrim(..., ",")`
- **gov_council.go**
  - Build `blacklistAddresses` and `authorizedAccountAddresses` using `splitAndTrim(..., ",")`
- **coin_adapter.go**
  - Build `minters` and `minterAllowed` using `splitAndTrim(..., ",")`
- **gov_master_minter.go**
  - Build `minterAddressStrs` from `mintersStr` using `splitAndTrim(..., ",")`
