### PR TITLE
fix: chainconfig engine mismatch

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2097,7 +2097,18 @@ func MakeChain(ctx *cli.Context, stack *node.Node, readonly bool) (*core.BlockCh
 		gspec   = MakeGenesis(ctx)
 		chainDb = MakeChainDatabase(ctx, stack, readonly)
 	)
-	config, err := core.LoadChainConfig(chainDb, gspec)
+
+	var overrides core.ChainOverrides
+	if ctx.IsSet(OverrideCancun.Name) {
+		v := ctx.Uint64(OverrideCancun.Name)
+		overrides.OverrideCancun = &v
+	}
+	if ctx.IsSet(OverrideVerkle.Name) {
+		v := ctx.Uint64(OverrideVerkle.Name)
+		overrides.OverrideVerkle = &v
+	}
+
+	config, err := core.LoadChainConfigWithOverride(chainDb, gspec, &overrides)
 	if err != nil {
 		Fatalf("%v", err)
 	}
@@ -2144,7 +2155,7 @@ func MakeChain(ctx *cli.Context, stack *node.Node, readonly bool) (*core.BlockCh
 	vmcfg := vm.Config{EnablePreimageRecording: ctx.Bool(VMEnableDebugFlag.Name)}
 
 	// Disable transaction indexing/unindexing by default.
-	chain, err := core.NewBlockChain(chainDb, cache, gspec, nil, engine, vmcfg, nil, nil)
+	chain, err := core.NewBlockChain(chainDb, cache, gspec, &overrides, engine, vmcfg, nil, nil)
 	if err != nil {
 		Fatalf("Can't create BlockChain: %v", err)
 	}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -378,6 +378,55 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 	return newcfg, stored, nil
 }
 
+// LoadChainConfigWithOverride loads the chain configuration from the database if present,
+// otherwise returns the config from the provided genesis specification, with overrides applied.
+func LoadChainConfigWithOverride(db ethdb.Database, genesis *Genesis, overrides *ChainOverrides) (*params.ChainConfig, common.Hash, error) {
+	applyOverrides := func(config *params.ChainConfig) {
+		if config != nil {
+			if overrides != nil && overrides.OverrideCancun != nil {
+				config.CancunTime = overrides.OverrideCancun
+			}
+			if overrides != nil && overrides.OverrideVerkle != nil {
+				config.VerkleTime = overrides.OverrideVerkle
+			}
+		}
+	}
+
+	stored := rawdb.ReadCanonicalHash(db, 0)
+	// If no genesis block is stored, use the provided genesis or default
+	if (stored == common.Hash{}) {
+		if genesis == nil {
+			genesis = DefaultStableNetMainnetGenesisBlock()
+		}
+		if genesis.Config == nil {
+			return params.AllEthashProtocolChanges, common.Hash{}, errGenesisNoConfig
+		}
+		applyOverrides(genesis.Config)
+		return genesis.Config, common.Hash{}, nil
+	}
+
+	// Genesis exists, get the config
+	newcfg := genesis.configOrDefault(stored)
+	applyOverrides(newcfg)
+
+	// Validate fork order
+	if err := newcfg.CheckConfigForkOrder(); err != nil {
+		return newcfg, common.Hash{}, err
+	}
+
+	// Check if there's a stored config in the database
+	storedcfg := rawdb.ReadChainConfig(db, stored)
+	if storedcfg != nil {
+		// Special case: private network - use stored config with overrides
+		if genesis == nil && stored != params.MainnetGenesisHash && stored != params.StableNetMainnetGenesisHash {
+			newcfg = storedcfg
+			applyOverrides(newcfg)
+		}
+	}
+
+	return newcfg, stored, nil
+}
+
 // LoadChainConfig loads the stored chain config if it is already present in
 // database, otherwise, return the config in the provided genesis specification.
 func LoadChainConfig(db ethdb.Database, genesis *Genesis) (*params.ChainConfig, error) {

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -380,7 +380,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 
 // LoadChainConfigWithOverride loads the chain configuration from the database if present,
 // otherwise returns the config from the provided genesis specification, with overrides applied.
-func LoadChainConfigWithOverride(db ethdb.Database, genesis *Genesis, overrides *ChainOverrides) (*params.ChainConfig, common.Hash, error) {
+func LoadChainConfigWithOverride(db ethdb.Database, genesis *Genesis, overrides *ChainOverrides) (*params.ChainConfig, error) {
 	applyOverrides := func(config *params.ChainConfig) {
 		if config != nil {
 			if overrides != nil && overrides.OverrideCancun != nil {
@@ -399,10 +399,10 @@ func LoadChainConfigWithOverride(db ethdb.Database, genesis *Genesis, overrides 
 			genesis = DefaultStableNetMainnetGenesisBlock()
 		}
 		if genesis.Config == nil {
-			return params.AllEthashProtocolChanges, common.Hash{}, errGenesisNoConfig
+			return params.AllEthashProtocolChanges, errGenesisNoConfig
 		}
 		applyOverrides(genesis.Config)
-		return genesis.Config, common.Hash{}, nil
+		return genesis.Config, nil
 	}
 
 	// Genesis exists, get the config
@@ -411,7 +411,7 @@ func LoadChainConfigWithOverride(db ethdb.Database, genesis *Genesis, overrides 
 
 	// Validate fork order
 	if err := newcfg.CheckConfigForkOrder(); err != nil {
-		return newcfg, common.Hash{}, err
+		return newcfg, err
 	}
 
 	// Check if there's a stored config in the database
@@ -424,7 +424,7 @@ func LoadChainConfigWithOverride(db ethdb.Database, genesis *Genesis, overrides 
 		}
 	}
 
-	return newcfg, stored, nil
+	return newcfg, nil
 }
 
 // LoadChainConfig loads the stored chain config if it is already present in

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -381,6 +381,10 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 // LoadChainConfigWithOverride loads the chain configuration from the database if present,
 // otherwise returns the config from the provided genesis specification, with overrides applied.
 func LoadChainConfigWithOverride(db ethdb.Database, genesis *Genesis, overrides *ChainOverrides) (*params.ChainConfig, error) {
+	if genesis != nil && genesis.Config == nil {
+		return params.AllEthashProtocolChanges, errGenesisNoConfig
+	}
+
 	applyOverrides := func(config *params.ChainConfig) {
 		if config != nil {
 			if overrides != nil && overrides.OverrideCancun != nil {
@@ -403,6 +407,29 @@ func LoadChainConfigWithOverride(db ethdb.Database, genesis *Genesis, overrides 
 		}
 		applyOverrides(genesis.Config)
 		return genesis.Config, nil
+	}
+
+	// If a canonical genesis already exists and a genesis is provided, ensure
+	// the provided genesis does not point to a different chain.
+	if genesis != nil {
+		applyOverrides(genesis.Config)
+		if genesis.Config.AnzeonEnabled() {
+			if err := genesis.Config.Anzeon.CheckValidity(); err != nil {
+				return nil, fmt.Errorf("Invalid genesis config: %v", err)
+			}
+			var err error
+			genesis.ExtraData, err = wbft.CreateInitialExtraData(genesis.Config.Anzeon)
+			if err != nil {
+				return genesis.Config, err
+			}
+			if err := InjectContracts(genesis, genesis.Config); err != nil {
+				return genesis.Config, err
+			}
+		}
+		hash := genesis.ToBlock().Hash()
+		if hash != stored {
+			return genesis.Config, &GenesisMismatchError{Stored: stored, New: hash}
+		}
 	}
 
 	// Genesis exists, get the config

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -216,6 +216,39 @@ type ChainOverrides struct {
 	OverrideVerkle *uint64
 }
 
+func applyOverrides(config *params.ChainConfig, overrides *ChainOverrides) {
+	if config == nil {
+		return
+	}
+	if overrides != nil && overrides.OverrideCancun != nil {
+		config.CancunTime = overrides.OverrideCancun
+	}
+	if overrides != nil && overrides.OverrideVerkle != nil {
+		config.VerkleTime = overrides.OverrideVerkle
+	}
+}
+
+func validateAnzeonGenesisConfig(config *params.ChainConfig) error {
+	if config != nil && config.AnzeonEnabled() {
+		if err := config.Anzeon.CheckValidity(); err != nil {
+			return fmt.Errorf("Invalid genesis config: %v", err)
+		}
+	}
+	return nil
+}
+
+func initializeAnzeonGenesis(genesis *Genesis) error {
+	if genesis == nil || genesis.Config == nil || !genesis.Config.AnzeonEnabled() {
+		return nil
+	}
+	extraData, err := wbft.CreateInitialExtraData(genesis.Config.Anzeon)
+	if err != nil {
+		return err
+	}
+	genesis.ExtraData = extraData
+	return InjectContracts(genesis, genesis.Config)
+}
+
 // SetupGenesisBlock writes or updates the genesis block in db.
 // The block that will be used is:
 //
@@ -237,16 +270,6 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 	if genesis != nil && genesis.Config == nil {
 		return params.AllEthashProtocolChanges, common.Hash{}, errGenesisNoConfig
 	}
-	applyOverrides := func(config *params.ChainConfig) {
-		if config != nil {
-			if overrides != nil && overrides.OverrideCancun != nil {
-				config.CancunTime = overrides.OverrideCancun
-			}
-			if overrides != nil && overrides.OverrideVerkle != nil {
-				config.VerkleTime = overrides.OverrideVerkle
-			}
-		}
-	}
 	// Just commit the new block if there is no stored genesis block.
 	stored := rawdb.ReadCanonicalHash(db, 0)
 	if (stored == common.Hash{}) {
@@ -256,22 +279,13 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 		} else {
 			log.Info("Writing custom genesis block")
 		}
-		applyOverrides(genesis.Config)
+		applyOverrides(genesis.Config, overrides)
 
-		if genesis.Config.AnzeonEnabled() {
-			if err := genesis.Config.Anzeon.CheckValidity(); err != nil {
-				return nil, common.Hash{}, fmt.Errorf("Invalid genesis config: %v", err)
-			}
-
-			var err error
-			genesis.ExtraData, err = wbft.CreateInitialExtraData(genesis.Config.Anzeon)
-			if err != nil {
-				return genesis.Config, common.Hash{}, err
-			}
-			err = InjectContracts(genesis, genesis.Config)
-			if err != nil {
-				return genesis.Config, common.Hash{}, err
-			}
+		if err := validateAnzeonGenesisConfig(genesis.Config); err != nil {
+			return nil, common.Hash{}, err
+		}
+		if err := initializeAnzeonGenesis(genesis); err != nil {
+			return genesis.Config, common.Hash{}, err
 		}
 		block, err := genesis.Commit(db, triedb)
 		if err != nil {
@@ -288,21 +302,13 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 		if genesis == nil {
 			genesis = DefaultStableNetMainnetGenesisBlock()
 		}
-		applyOverrides(genesis.Config)
+		applyOverrides(genesis.Config, overrides)
 
-		if genesis.Config.AnzeonEnabled() {
-			if err := genesis.Config.Anzeon.CheckValidity(); err != nil {
-				return nil, common.Hash{}, fmt.Errorf("Invalid genesis config: %v", err)
-			}
-			var err error
-			genesis.ExtraData, err = wbft.CreateInitialExtraData(genesis.Config.Anzeon)
-			if err != nil {
-				return genesis.Config, stored, err
-			}
-			err = InjectContracts(genesis, genesis.Config)
-			if err != nil {
-				return genesis.Config, stored, err
-			}
+		if err := validateAnzeonGenesisConfig(genesis.Config); err != nil {
+			return nil, common.Hash{}, err
+		}
+		if err := initializeAnzeonGenesis(genesis); err != nil {
+			return genesis.Config, stored, err
 		}
 
 		// Ensure the stored genesis matches with the given one.
@@ -318,21 +324,12 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 	}
 	// Check whether the genesis block is already written.
 	if genesis != nil {
-		applyOverrides(genesis.Config)
-		if genesis.Config.AnzeonEnabled() {
-			if err := genesis.Config.Anzeon.CheckValidity(); err != nil {
-				return nil, common.Hash{}, fmt.Errorf("Invalid genesis config: %v", err)
-			}
-
-			var err error
-			genesis.ExtraData, err = wbft.CreateInitialExtraData(genesis.Config.Anzeon)
-			if err != nil {
-				return genesis.Config, common.Hash{}, err
-			}
-			err = InjectContracts(genesis, genesis.Config)
-			if err != nil {
-				return genesis.Config, common.Hash{}, err
-			}
+		applyOverrides(genesis.Config, overrides)
+		if err := validateAnzeonGenesisConfig(genesis.Config); err != nil {
+			return nil, common.Hash{}, err
+		}
+		if err := initializeAnzeonGenesis(genesis); err != nil {
+			return genesis.Config, common.Hash{}, err
 		}
 		hash := genesis.ToBlock().Hash()
 		if hash != stored {
@@ -341,7 +338,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 	}
 	// Get the existing chain configuration.
 	newcfg := genesis.configOrDefault(stored)
-	applyOverrides(newcfg)
+	applyOverrides(newcfg, overrides)
 	if err := newcfg.CheckConfigForkOrder(); err != nil {
 		return newcfg, common.Hash{}, err
 	}
@@ -359,7 +356,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 	// apply the overrides.
 	if genesis == nil && stored != params.MainnetGenesisHash && stored != params.StableNetMainnetGenesisHash {
 		newcfg = storedcfg
-		applyOverrides(newcfg)
+		applyOverrides(newcfg, overrides)
 	}
 	// Check config compatibility and write the config. Compatibility errors
 	// are returned to the caller unless we're already at block zero.
@@ -385,17 +382,6 @@ func LoadChainConfigWithOverride(db ethdb.Database, genesis *Genesis, overrides 
 		return params.AllEthashProtocolChanges, errGenesisNoConfig
 	}
 
-	applyOverrides := func(config *params.ChainConfig) {
-		if config != nil {
-			if overrides != nil && overrides.OverrideCancun != nil {
-				config.CancunTime = overrides.OverrideCancun
-			}
-			if overrides != nil && overrides.OverrideVerkle != nil {
-				config.VerkleTime = overrides.OverrideVerkle
-			}
-		}
-	}
-
 	stored := rawdb.ReadCanonicalHash(db, 0)
 	// If no genesis block is stored, use the provided genesis or default
 	if (stored == common.Hash{}) {
@@ -405,26 +391,19 @@ func LoadChainConfigWithOverride(db ethdb.Database, genesis *Genesis, overrides 
 		if genesis.Config == nil {
 			return params.AllEthashProtocolChanges, errGenesisNoConfig
 		}
-		applyOverrides(genesis.Config)
+		applyOverrides(genesis.Config, overrides)
 		return genesis.Config, nil
 	}
 
 	// If a canonical genesis already exists and a genesis is provided, ensure
 	// the provided genesis does not point to a different chain.
 	if genesis != nil {
-		applyOverrides(genesis.Config)
-		if genesis.Config.AnzeonEnabled() {
-			if err := genesis.Config.Anzeon.CheckValidity(); err != nil {
-				return nil, fmt.Errorf("Invalid genesis config: %v", err)
-			}
-			var err error
-			genesis.ExtraData, err = wbft.CreateInitialExtraData(genesis.Config.Anzeon)
-			if err != nil {
-				return genesis.Config, err
-			}
-			if err := InjectContracts(genesis, genesis.Config); err != nil {
-				return genesis.Config, err
-			}
+		applyOverrides(genesis.Config, overrides)
+		if err := validateAnzeonGenesisConfig(genesis.Config); err != nil {
+			return nil, err
+		}
+		if err := initializeAnzeonGenesis(genesis); err != nil {
+			return genesis.Config, err
 		}
 		hash := genesis.ToBlock().Hash()
 		if hash != stored {
@@ -434,7 +413,7 @@ func LoadChainConfigWithOverride(db ethdb.Database, genesis *Genesis, overrides 
 
 	// Genesis exists, get the config
 	newcfg := genesis.configOrDefault(stored)
-	applyOverrides(newcfg)
+	applyOverrides(newcfg, overrides)
 
 	// Validate fork order
 	if err := newcfg.CheckConfigForkOrder(); err != nil {
@@ -447,7 +426,7 @@ func LoadChainConfigWithOverride(db ethdb.Database, genesis *Genesis, overrides 
 		// Special case: private network - use stored config with overrides
 		if genesis == nil && stored != params.MainnetGenesisHash && stored != params.StableNetMainnetGenesisHash {
 			newcfg = storedcfg
-			applyOverrides(newcfg)
+			applyOverrides(newcfg, overrides)
 		}
 	}
 

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -49,6 +49,117 @@ func TestSetupGenesis(t *testing.T) {
 	testSetupGenesis(t, rawdb.PathScheme)
 }
 
+func TestLoadChainConfigWithOverride(t *testing.T) {
+	t.Run("no block in DB, genesis with overrides", func(t *testing.T) {
+		db := rawdb.NewMemoryDatabase()
+		cancunTime := uint64(1234)
+
+		config := *params.TestChainConfig
+		genesis := &Genesis{
+			Config:     &config,
+			GasLimit:   4712388,
+			Difficulty: big.NewInt(1),
+			Alloc: types.GenesisAlloc{
+				{1}: {Balance: big.NewInt(1)},
+			},
+		}
+		got, err := LoadChainConfigWithOverride(db, genesis, &ChainOverrides{OverrideCancun: &cancunTime})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.CancunTime == nil || *got.CancunTime != cancunTime {
+			t.Fatalf("override not applied, got=%v want=%d", got.CancunTime, cancunTime)
+		}
+	})
+
+	t.Run("private network in DB, genesis nil uses stored config with overrides", func(t *testing.T) {
+		db := rawdb.NewMemoryDatabase()
+		verkleTime := uint64(5678)
+
+		config := *params.TestChainConfig
+		config.ChainID = big.NewInt(1337)
+		genesis := &Genesis{
+			Config:     &config,
+			GasLimit:   4712388,
+			Difficulty: big.NewInt(1),
+			Alloc: types.GenesisAlloc{
+				{1}: {Balance: big.NewInt(1)},
+			},
+		}
+		block := genesis.MustCommit(db, triedb.NewDatabase(db, triedb.HashDefaults))
+
+		got, err := LoadChainConfigWithOverride(db, nil, &ChainOverrides{OverrideVerkle: &verkleTime})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.ChainID.Cmp(config.ChainID) != 0 {
+			t.Fatalf("unexpected chain id, got=%v want=%v", got.ChainID, config.ChainID)
+		}
+		if got.VerkleTime == nil || *got.VerkleTime != verkleTime {
+			t.Fatalf("override not applied, got=%v want=%d", got.VerkleTime, verkleTime)
+		}
+		storedcfg := rawdb.ReadChainConfig(db, block.Hash())
+		if storedcfg == nil {
+			t.Fatalf("stored chain config missing")
+		}
+		if storedcfg.ChainID.Cmp(got.ChainID) != 0 {
+			t.Fatalf("unexpected stored chain id, got=%v want=%v", storedcfg.ChainID, got.ChainID)
+		}
+	})
+
+	t.Run("stored genesis with mismatching provided genesis returns mismatch error", func(t *testing.T) {
+		db := rawdb.NewMemoryDatabase()
+
+		config := *params.TestChainConfig
+		config.ChainID = big.NewInt(9999)
+		storedGenesis := &Genesis{
+			Config:     &config,
+			GasLimit:   4712388,
+			Difficulty: big.NewInt(1),
+			Alloc: types.GenesisAlloc{
+				{1}: {Balance: big.NewInt(1)},
+			},
+		}
+		block := storedGenesis.MustCommit(db, triedb.NewDatabase(db, triedb.HashDefaults))
+
+		mismatchGenesis := &Genesis{
+			Config:     &config,
+			GasLimit:   4712388,
+			Difficulty: big.NewInt(1),
+			Nonce:      1, // force different genesis hash
+			Alloc: types.GenesisAlloc{
+				{1}: {Balance: big.NewInt(1)},
+			},
+		}
+
+		_, err := LoadChainConfigWithOverride(db, mismatchGenesis, nil)
+		if err == nil {
+			t.Fatalf("expected mismatch error")
+		}
+		mismatchErr, ok := err.(*GenesisMismatchError)
+		if !ok {
+			t.Fatalf("unexpected error type: %T", err)
+		}
+		if mismatchErr.Stored != block.Hash() {
+			t.Fatalf("unexpected stored hash, got=%s want=%s", mismatchErr.Stored, block.Hash())
+		}
+		if mismatchErr.New != mismatchGenesis.ToBlock().Hash() {
+			t.Fatalf("unexpected new hash, got=%s want=%s", mismatchErr.New, mismatchGenesis.ToBlock().Hash())
+		}
+	})
+
+	t.Run("genesis without config returns errGenesisNoConfig", func(t *testing.T) {
+		db := rawdb.NewMemoryDatabase()
+		got, err := LoadChainConfigWithOverride(db, new(Genesis), nil)
+		if err != errGenesisNoConfig {
+			t.Fatalf("unexpected error, got=%v want=%v", err, errGenesisNoConfig)
+		}
+		if got != params.AllEthashProtocolChanges {
+			t.Fatalf("unexpected config return for error path")
+		}
+	})
+}
+
 func testSetupGenesis(t *testing.T, scheme string) {
 	var (
 		customghash = common.HexToHash("0x89c99d90b79719238d2645c7642f2c9295246e80775b38cfd162b696817fbd50")

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -145,8 +145,18 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			log.Error("Failed to recover state", "error", err)
 		}
 	}
+
+	// Override the chain config with provided settings.
+	var overrides core.ChainOverrides
+	if config.OverrideCancun != nil {
+		overrides.OverrideCancun = config.OverrideCancun
+	}
+	if config.OverrideVerkle != nil {
+		overrides.OverrideVerkle = config.OverrideVerkle
+	}
+
 	// Transfer mining-related config to the ethash config.
-	chainConfig, err := core.LoadChainConfig(chainDb, config.Genesis)
+	chainConfig, _, err := core.LoadChainConfigWithOverride(chainDb, config.Genesis, &overrides)
 	if err != nil {
 		return nil, err
 	}
@@ -214,14 +224,6 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			StateScheme:         scheme,
 		}
 	)
-	// Override the chain config with provided settings.
-	var overrides core.ChainOverrides
-	if config.OverrideCancun != nil {
-		overrides.OverrideCancun = config.OverrideCancun
-	}
-	if config.OverrideVerkle != nil {
-		overrides.OverrideVerkle = config.OverrideVerkle
-	}
 	eth.blockchain, err = core.NewBlockChain(chainDb, cacheConfig, config.Genesis, &overrides, eth.engine, vmConfig, eth.shouldPreserve, &config.TransactionHistory)
 	if err != nil {
 		return nil, err

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -156,7 +156,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	}
 
 	// Transfer mining-related config to the ethash config.
-	chainConfig, _, err := core.LoadChainConfigWithOverride(chainDb, config.Genesis, &overrides)
+	chainConfig, err := core.LoadChainConfigWithOverride(chainDb, config.Genesis, &overrides)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

This PR fixes an issue where the WBFT consensus engine is initialized using a stale ChainConfig loaded from the database before chain config overrides are applied.

As a result, hardfork settings defined in the genesis or via code-level overrides were not reflected in the consensus engine at initialization time, causing a mismatch between the blockchain and the engine configuration.

This change ensures that the consensus engine is always created using the final ChainConfig with overrides applied.

## Background

In the standard Ethereum initialization flow, the final ChainConfig is resolved inside NewBlockChain via SetupGenesisBlockWithOverride.

However, in the current go-stablenet flow:
1.	LoadChainConfig loads the ChainConfig from the database
2.	The consensus engine is created using this ChainConfig
3.	NewBlockChain later applies overrides through SetupGenesisBlockWithOverride, producing the final ChainConfig

This leads to the consensus engine and the blockchain using different ChainConfig values.

## Problem
| Component | ChainConfig used |
|-----------|------------------|
| Consensus engine | Stored ChainConfig (overrides not applied) |
| Blockchain | Final ChainConfig returned by `SetupGenesisBlockWithOverride` |

## Impact
- Hardfork-related settings are not reflected in the consensus engine
- WBFT engine initialization (e.g. Transitions, SystemContractUpgrades) is based on outdated configuration
- Potential for unexpected consensus behavior or block validation errors due to configuration mismatch

## Solution

**Key idea**

Use a lightweight helper that resolves the final ChainConfig with overrides applied without committing the genesis block, and use it to initialize the consensus engine.

**Changes**
1. Add LoadChainConfigWithOverride
- Loads ChainConfig from the database or genesis
- Applies overrides
- Uses the same config-resolution logic as SetupGenesisBlockWithOverride
2. Update engine initialization flow (eth/backend.go)
- Build overrides before engine creation
- Replace LoadChainConfig with LoadChainConfigWithOverride
- Create the consensus engine using the override-applied ChainConfig
3. No changes to NewBlockChain signature
- No impact on existing callers or tests
