### PR TITLE
fix: include AuthorizationList in gas estimation (#33849)

### DIFF
--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -168,6 +168,7 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend, skipGas
 				AccessList:           args.AccessList,
 				BlobFeeCap:           args.BlobFeeCap,
 				BlobHashes:           args.BlobHashes,
+				AuthorizationList:    args.AuthorizationList,
 			}
 			latestBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 			estimated, err := DoEstimateGas(ctx, b, callArgs, latestBlockNr, nil, b.RPCGasCap())


### PR DESCRIPTION
The `callArgs` constructed for gas estimation in `setDefaults` was missing `AuthorizationList`.

This can cause the following issues for EIP-7702 SetCode transactions without an explicit gas value:

- Code delegations from authorizations are not applied during estimation, potentially altering the execution path entirely
- Incorrect gas estimates leading to out-of-gas failures

**Reference:** [ethereum/go-ethereum#33849](https://github.com/ethereum/go-ethereum/pull/33849)