### PR TITLE
fix: move secp256r1 precompile from Anzeon to Boho fork

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -136,6 +136,20 @@ var PrecompiledContractsAnzeon = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{9}):    &blake2F{},
 	common.BytesToAddress([]byte{0x0a}): &kzgPointEvaluation{},
 	params.BLSPoPPrecompileAddress:      &blsPoP{},
+}
+
+var PrecompiledContractsBoho = map[common.Address]PrecompiledContract{
+	common.BytesToAddress([]byte{1}):    &ecrecover{},
+	common.BytesToAddress([]byte{2}):    &sha256hash{},
+	common.BytesToAddress([]byte{3}):    &ripemd160hash{},
+	common.BytesToAddress([]byte{4}):    &dataCopy{},
+	common.BytesToAddress([]byte{5}):    &bigModExp{eip2565: true},
+	common.BytesToAddress([]byte{6}):    &bn256AddIstanbul{},
+	common.BytesToAddress([]byte{7}):    &bn256ScalarMulIstanbul{},
+	common.BytesToAddress([]byte{8}):    &bn256PairingIstanbul{},
+	common.BytesToAddress([]byte{9}):    &blake2F{},
+	common.BytesToAddress([]byte{0x0a}): &kzgPointEvaluation{},
+	params.BLSPoPPrecompileAddress:      &blsPoP{},
 
 	common.BytesToAddress([]byte{0x1, 0x00}): &p256Verify{},
 }
@@ -147,6 +161,7 @@ var PrecompiledContractsP256Verify = map[common.Address]PrecompiledContract{
 }
 
 var (
+	PrecompiledAddressesBoho      []common.Address
 	PrecompiledAddressesAnzeon    []common.Address
 	PrecompiledAddressesCancun    []common.Address
 	PrecompiledAddressesBerlin    []common.Address
@@ -174,11 +189,16 @@ func init() {
 	for k := range PrecompiledContractsAnzeon {
 		PrecompiledAddressesAnzeon = append(PrecompiledAddressesAnzeon, k)
 	}
+	for k := range PrecompiledContractsBoho {
+		PrecompiledAddressesBoho = append(PrecompiledAddressesBoho, k)
+	}
 }
 
 // ActivePrecompiles returns the precompiles enabled with the current configuration.
 func ActivePrecompiles(rules params.Rules) []common.Address {
 	switch {
+	case rules.IsBoho:
+		return PrecompiledAddressesBoho
 	case rules.IsAnzeon:
 		return PrecompiledAddressesAnzeon
 	case rules.IsCancun:

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -40,6 +40,8 @@ type (
 func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool) {
 	var precompiles map[common.Address]PrecompiledContract
 	switch {
+	case evm.chainRules.IsBoho:
+		precompiles = PrecompiledContractsBoho
 	case evm.chainRules.IsAnzeon:
 		precompiles = PrecompiledContractsAnzeon
 	case evm.chainRules.IsCancun:


### PR DESCRIPTION
## Summary
- Introduce `PrecompiledContractsBoho` as a new precompile set for the Boho fork
- Move `p256Verify` (secp256r1) precompile from the Anzeon fork to `PrecompiledContractsBoho`

## Background
The testnet was already live on the Anzeon fork **without** secp256r1 support when #53 added `p256Verify` to the Anzeon precompile set. This introduced a potential consensus issue: any transaction that had previously failed due to an unrecognized precompile address would now succeed upon re-validation, breaking historical state consistency.

At the time of #53, there were assumed to be no such transactions on the testnet, so it was merged with an explicit **breaking change** notice warning that older node versions must not be used once the release is deployed.

## What Changed & Why
With the introduction of the Boho fork, `p256Verify` is now anchored to a clean, dedicated fork block. Since secp256r1 was never activated on the live testnet under the Anzeon fork, moving it to Boho:

- Eliminates the tx execution inconsistency during block sync/validation across different node versions
- Makes secp256r1 availability deterministic from the Boho block onward
- Renders the breaking change warning from #53 obsolete