### PR TITLE
fix: fill missing effectiveGasPrice in receipts on derivation

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2107,7 +2107,7 @@ func (bc *BlockChain) collectLogs(b *types.Block, removed bool) []*types.Log {
 	}
 	receipts := rawdb.ReadRawReceipts(bc.db, b.Hash(), b.NumberU64())
 
-	if err := receipts.DeriveFields(bc.chainConfig, b.Hash(), b.NumberU64(), b.Time(), b.BaseFee(), blobGasPrice, b.Transactions()); err != nil {
+	if err := receipts.DeriveFields(bc.chainConfig, b.Hash(), b.NumberU64(), b.Time(), b.BaseFee(), b.Header().GasTip(), blobGasPrice, b.Transactions()); err != nil {
 		log.Error("Failed to derive block receipts fields", "hash", b.Hash(), "number", b.NumberU64(), "err", err)
 	}
 	var logs []*types.Log

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -409,7 +409,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 			blobGasPrice = eip4844.CalcBlobFee(*block.ExcessBlobGas())
 		}
 
-		if err := receipts.DeriveFields(config, block.Hash(), block.NumberU64(), block.Time(), block.BaseFee(), blobGasPrice, txs); err != nil {
+		if err := receipts.DeriveFields(config, block.Hash(), block.NumberU64(), block.Time(), block.BaseFee(), block.Header().GasTip(), blobGasPrice, txs); err != nil {
 			panic(err)
 		}
 

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -653,7 +653,12 @@ func ReadReceipts(db ethdb.Reader, hash common.Hash, number uint64, time uint64,
 		blobGasPrice = eip4844.CalcBlobFee(*header.ExcessBlobGas)
 	}
 
-	if err := receipts.DeriveFields(config, hash, number, time, baseFee, blobGasPrice, body.Transactions); err != nil {
+	var headerGasTip *big.Int
+	if header != nil {
+		headerGasTip = header.GasTip()
+	}
+
+	if err := receipts.DeriveFields(config, hash, number, time, baseFee, headerGasTip, blobGasPrice, body.Transactions); err != nil {
 		log.Error("Failed to derive block receipts fields", "hash", hash, "number", number, "err", err)
 		return nil
 	}

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -657,6 +657,7 @@ func TestApplyTransactionAuthorizedAccount(t *testing.T) {
 	coinbase := common.Address{0x1} // Use a non-zero address for coinbase
 	gp := new(GasPool).AddGas(header.GasLimit)
 	usedGas := uint64(0)
+	stateDB.SetTxContext(tx.Hash(), 0)
 	receipt, err := ApplyTransaction(config, nil, &coinbase, gp, stateDB, header, tx, &usedGas, vm.Config{})
 	if err != nil {
 		t.Fatalf("failed to apply transaction: %v", err)
@@ -706,8 +707,19 @@ func TestApplyTransactionAuthorizedAccount(t *testing.T) {
 			expectedTotalGasFee, receipt.GasUsed, expectedEffectiveGasPrice, actualTotalGasFee)
 	}
 
-	t.Logf("Authorized account - GasUsed: %d, EffectiveGasPrice: %v, TotalGasFee: %v",
-		receipt.GasUsed, actualEffectiveGasPrice, actualTotalGasFee)
+	t.Logf("Authorized account - GasUsed: %d, EffectiveGasPrice: %v, TotalGasFee: %v", receipt.GasUsed, actualEffectiveGasPrice, actualTotalGasFee)
+
+	// Verify AuthorizedTxExecuted event is the last log of the receipt
+	if len(receipt.Logs) == 0 {
+		t.Fatal("expected at least one log in receipt")
+	}
+	lastLog := receipt.Logs[len(receipt.Logs)-1]
+	if lastLog.Address != params.AccountManagerAddress {
+		t.Errorf("expected last log address %v, got %v", params.AccountManagerAddress, lastLog.Address)
+	}
+	if lastLog.Topics[0] != params.AuthorizedTxExecutedEventSig {
+		t.Errorf("expected last log topic %v, got %v", params.AuthorizedTxExecutedEventSig, lastLog.Topics[0])
+	}
 }
 
 // TestApplyTransactionNormalAccount tests that normal accounts pay actual gas fee based on header's gas tip
@@ -803,6 +815,7 @@ func TestApplyTransactionNormalAccount(t *testing.T) {
 	coinbase := common.Address{0x1} // Use a non-zero address for coinbase
 	gp := new(GasPool).AddGas(header.GasLimit)
 	usedGas := uint64(0)
+	stateDB.SetTxContext(tx.Hash(), 0)
 	receipt, err := ApplyTransaction(config, nil, &coinbase, gp, stateDB, header, tx, &usedGas, vm.Config{})
 	if err != nil {
 		t.Fatalf("failed to apply transaction: %v", err)
@@ -855,4 +868,12 @@ func TestApplyTransactionNormalAccount(t *testing.T) {
 
 	t.Logf("Normal account - GasUsed: %d, EffectiveGasPrice: %v, TotalGasFee: %v",
 		receipt.GasUsed, actualEffectiveGasPrice, actualTotalGasFee)
+
+	// Verify AuthorizedTxExecuted event is NOT present in receipt logs
+	for _, log := range receipt.Logs {
+		if log.Address == params.AccountManagerAddress &&
+			len(log.Topics) > 0 && log.Topics[0] == params.AuthorizedTxExecutedEventSig {
+			t.Error("normal account should not emit AuthorizedTxExecuted event")
+		}
+	}
 }

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -590,7 +590,6 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 			Address: params.AccountManagerAddress,
 			Topics: []common.Hash{
 				params.AuthorizedTxExecutedEventSig,
-				common.BytesToHash(common.LeftPadBytes(msg.From.Bytes(), 32)),
 			},
 		})
 	}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -580,6 +580,21 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		}
 	}
 
+	// Emit an AuthorizedTxExecuted event for authorized account transactions.
+	// Used by DeriveFields to determine effective gas price without state access.
+	//
+	// NOTE: Must be the last log added — DeriveFields checks only the final
+	// log of the receipt to identify authorized transactions.
+	if rules.IsAnzeon && st.state.IsAuthorized(msg.From) {
+		st.state.AddLog(&types.Log{
+			Address: params.AccountManagerAddress,
+			Topics: []common.Hash{
+				params.AuthorizedTxExecutedEventSig,
+				common.BytesToHash(common.LeftPadBytes(msg.From.Bytes(), 32)),
+			},
+		})
+	}
+
 	return &ExecutionResult{
 		UsedGas:     st.gasUsed(),
 		RefundedGas: gasRefund,

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -457,6 +457,7 @@ func hasAuthorizedTxLog(r *Receipt) bool {
 	if logs := r.Logs; len(logs) > 0 {
 		last := logs[len(logs)-1]
 		if last.Address == params.AccountManagerAddress &&
+			len(last.Topics) > 0 &&
 			last.Topics[0] == params.AuthorizedTxExecutedEventSig {
 			return true
 		}

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	cmath "github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -381,7 +382,7 @@ func (atEnv *anzeonTipEnv) IsAnzeon() bool {
 
 // DeriveFields fills the receipts with their computed fields based on consensus
 // data and contextual infos like containing block and transactions.
-func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, number uint64, time uint64, baseFee, blobGasPrice *big.Int, txs []*Transaction) error {
+func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, number uint64, time uint64, baseFee, headerGasTip, blobGasPrice *big.Int, txs []*Transaction) error {
 	signer := MakeSigner(config, new(big.Int).SetUint64(number), time)
 
 	logIndex := uint(0)
@@ -394,6 +395,19 @@ func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, nu
 		rs[i].TxHash = txs[i].Hash()
 		if !config.AnzeonEnabled() {
 			rs[i].EffectiveGasPrice = txs[i].inner.effectiveGasPrice(new(big.Int), baseFee)
+		} else if rs[i].EffectiveGasPrice == nil {
+			// In Anzeon, effectiveGasPrice may be nil for some receipts (e.g. receipts
+			// received via snap sync). Recompute it using headerGasTip and the authorized
+			// account status derived from the receipt logs.
+			gasTipCap := txs[i].GasTipCap()
+			if headerGasTip != nil && !hasAuthorizedTxLog(rs[i]) {
+				gasTipCap = headerGasTip
+			}
+			if baseFee != nil {
+				rs[i].EffectiveGasPrice = cmath.BigMin(new(big.Int).Add(gasTipCap, baseFee), txs[i].GasFeeCap())
+			} else {
+				rs[i].EffectiveGasPrice = txs[i].GasPrice()
+			}
 		}
 		// EIP-4844 blob transaction fields
 		if txs[i].Type() == BlobTxType {
@@ -433,4 +447,19 @@ func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, nu
 		}
 	}
 	return nil
+}
+
+// hasAuthorizedTxLog reports whether the transaction was executed by an
+// authorized account, by checking for an AuthorizedTxExecuted event in the
+// receipt. This event is always emitted as the last log of the transaction
+// (see TransitionDb), so only the final log needs to be inspected.
+func hasAuthorizedTxLog(r *Receipt) bool {
+	if logs := r.Logs; len(logs) > 0 {
+		last := logs[len(logs)-1]
+		if last.Address == params.AccountManagerAddress &&
+			last.Topics[0] == params.AuthorizedTxExecutedEventSig {
+			return true
+		}
+	}
+	return false
 }

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -258,7 +258,7 @@ var (
 			// derived fields:
 			TxHash:            txs[4].Hash(),
 			GasUsed:           5,
-			EffectiveGasPrice: big.NewInt(3000), // anzeon disabled(no sign in tx)
+			EffectiveGasPrice: big.NewInt(3000),
 			BlockHash:         blockHash,
 			BlockNumber:       blockNumber,
 			TransactionIndex:  4,
@@ -294,7 +294,10 @@ var (
 			TransactionIndex:  6,
 		},
 	}
-	authorizedReceipts = Receipts{
+
+	// anzeonReceipts represents receipts for non-authorized accounts in Anzeon.
+	// effectiveGasPrice is computed as min(headerGasTip + baseFee, GasFeeCap).
+	anzeonReceipts = Receipts{
 		&Receipt{
 			Status:            ReceiptStatusFailed,
 			CumulativeGasUsed: 1,
@@ -383,7 +386,7 @@ var (
 			// derived fields:
 			TxHash:            txs[3].Hash(),
 			GasUsed:           4,
-			EffectiveGasPrice: big.NewInt(2000),
+			EffectiveGasPrice: big.NewInt(1500), // min(headerGasTip=500 + baseFee=1000, GasFeeCap=2000) = 1500
 			BlockHash:         blockHash,
 			BlockNumber:       blockNumber,
 			TransactionIndex:  3,
@@ -396,6 +399,216 @@ var (
 			// derived fields:
 			TxHash:            txs[4].Hash(),
 			GasUsed:           5,
+			EffectiveGasPrice: big.NewInt(1500), // min(headerGasTip=500 + baseFee=1000, GasFeeCap=4000) = 1500
+			BlockHash:         blockHash,
+			BlockNumber:       blockNumber,
+			TransactionIndex:  4,
+		},
+		&Receipt{
+			Type:              BlobTxType,
+			PostState:         common.Hash{6}.Bytes(),
+			CumulativeGasUsed: 21,
+			Logs: []*Log{
+				// This log has the AuthorizedTxExecutedEventSig topic but is emitted from
+				// an address other than AccountManagerAddress. This verifies that
+				// hasAuthorizedTxLog only matches when both the address and topic are correct,
+				// and does not misidentify this transaction as authorized.
+				{
+					Address: params.NativeCoinManagerAddress,
+					Topics:  []common.Hash{params.AuthorizedTxExecutedEventSig},
+					// derived fields:
+					BlockNumber: blockNumber.Uint64(),
+					TxHash:      txs[5].Hash(),
+					TxIndex:     5,
+					BlockHash:   blockHash,
+					Index:       4,
+				},
+			},
+			// derived fields:
+			TxHash:            txs[5].Hash(),
+			GasUsed:           6,
+			EffectiveGasPrice: big.NewInt(1500), // min(headerGasTip=500 + baseFee=1000, GasFeeCap=2000) = 1500
+			BlobGasUsed:       params.BlobTxBlobGasPerBlob,
+			BlobGasPrice:      big.NewInt(920),
+			BlockHash:         blockHash,
+			BlockNumber:       blockNumber,
+			TransactionIndex:  5,
+		},
+		&Receipt{
+			Type:              BlobTxType,
+			PostState:         common.Hash{7}.Bytes(),
+			CumulativeGasUsed: 28,
+			Logs:              []*Log{},
+			// derived fields:
+			TxHash:            txs[6].Hash(),
+			GasUsed:           7,
+			EffectiveGasPrice: big.NewInt(1500), // min(headerGasTip=500 + baseFee=1000, GasFeeCap=3000) = 1500
+			BlobGasUsed:       3 * params.BlobTxBlobGasPerBlob,
+			BlobGasPrice:      big.NewInt(920),
+			BlockHash:         blockHash,
+			BlockNumber:       blockNumber,
+			TransactionIndex:  6,
+		},
+	}
+
+	// authorizedReceipts represents receipts for authorized accounts in Anzeon.
+	// effectiveGasPrice is computed as min(GasTipCap + baseFee, GasFeeCap), using
+	// the transaction's own GasTipCap instead of the header gas tip.
+	authorizedReceipts = Receipts{
+		&Receipt{
+			Status:            ReceiptStatusFailed,
+			CumulativeGasUsed: 1,
+			Logs: []*Log{
+				{
+					Address: common.BytesToAddress([]byte{0x11}),
+					Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
+					// derived fields:
+					BlockNumber: blockNumber.Uint64(),
+					TxHash:      txs[0].Hash(),
+					TxIndex:     0,
+					BlockHash:   blockHash,
+					Index:       0,
+				},
+				{
+					Address: common.BytesToAddress([]byte{0x01, 0x11}),
+					Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
+					// derived fields:
+					BlockNumber: blockNumber.Uint64(),
+					TxHash:      txs[0].Hash(),
+					TxIndex:     0,
+					BlockHash:   blockHash,
+					Index:       1,
+				},
+				{
+					Address: params.AccountManagerAddress,
+					Topics:  []common.Hash{params.AuthorizedTxExecutedEventSig},
+					// derived fields:
+					BlockNumber: blockNumber.Uint64(),
+					TxHash:      txs[0].Hash(),
+					TxIndex:     0,
+					BlockHash:   blockHash,
+					Index:       2,
+				},
+			},
+			// derived fields:
+			TxHash:            txs[0].Hash(),
+			ContractAddress:   common.HexToAddress("0x5a443704dd4b594b382c22a083e2bd3090a6fef3"),
+			GasUsed:           1,
+			EffectiveGasPrice: big.NewInt(11),
+			BlockHash:         blockHash,
+			BlockNumber:       blockNumber,
+			TransactionIndex:  0,
+		},
+		&Receipt{
+			PostState:         common.Hash{2}.Bytes(),
+			CumulativeGasUsed: 3,
+			Logs: []*Log{
+				{
+					Address: common.BytesToAddress([]byte{0x22}),
+					Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
+					// derived fields:
+					BlockNumber: blockNumber.Uint64(),
+					TxHash:      txs[1].Hash(),
+					TxIndex:     1,
+					BlockHash:   blockHash,
+					Index:       3,
+				},
+				{
+					Address: common.BytesToAddress([]byte{0x02, 0x22}),
+					Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
+					// derived fields:
+					BlockNumber: blockNumber.Uint64(),
+					TxHash:      txs[1].Hash(),
+					TxIndex:     1,
+					BlockHash:   blockHash,
+					Index:       4,
+				},
+				{
+					Address: params.AccountManagerAddress,
+					Topics:  []common.Hash{params.AuthorizedTxExecutedEventSig},
+					// derived fields:
+					BlockNumber: blockNumber.Uint64(),
+					TxHash:      txs[1].Hash(),
+					TxIndex:     1,
+					BlockHash:   blockHash,
+					Index:       5,
+				},
+			},
+			// derived fields:
+			TxHash:            txs[1].Hash(),
+			GasUsed:           2,
+			EffectiveGasPrice: big.NewInt(22),
+			BlockHash:         blockHash,
+			BlockNumber:       blockNumber,
+			TransactionIndex:  1,
+		},
+		&Receipt{
+			Type:              AccessListTxType,
+			PostState:         common.Hash{3}.Bytes(),
+			CumulativeGasUsed: 6,
+			Logs: []*Log{
+				{
+					Address: params.AccountManagerAddress,
+					Topics:  []common.Hash{params.AuthorizedTxExecutedEventSig},
+					// derived fields:
+					BlockNumber: blockNumber.Uint64(),
+					TxHash:      txs[2].Hash(),
+					TxIndex:     2,
+					BlockHash:   blockHash,
+					Index:       6,
+				},
+			},
+			// derived fields:
+			TxHash:            txs[2].Hash(),
+			GasUsed:           3,
+			EffectiveGasPrice: big.NewInt(33),
+			BlockHash:         blockHash,
+			BlockNumber:       blockNumber,
+			TransactionIndex:  2,
+		},
+		&Receipt{
+			Type:              DynamicFeeTxType,
+			PostState:         common.Hash{4}.Bytes(),
+			CumulativeGasUsed: 10,
+			Logs: []*Log{
+				{
+					Address: params.AccountManagerAddress,
+					Topics:  []common.Hash{params.AuthorizedTxExecutedEventSig},
+					// derived fields:
+					BlockNumber: blockNumber.Uint64(),
+					TxHash:      txs[3].Hash(),
+					TxIndex:     3,
+					BlockHash:   blockHash,
+					Index:       7,
+				},
+			},
+			// derived fields:
+			TxHash:            txs[3].Hash(),
+			GasUsed:           4,
+			EffectiveGasPrice: big.NewInt(2000),
+			BlockHash:         blockHash,
+			BlockNumber:       blockNumber,
+			TransactionIndex:  3,
+		},
+		&Receipt{
+			Type:              DynamicFeeTxType,
+			PostState:         common.Hash{5}.Bytes(),
+			CumulativeGasUsed: 15,
+			Logs: []*Log{
+				{
+					Address: params.AccountManagerAddress,
+					Topics:  []common.Hash{params.AuthorizedTxExecutedEventSig},
+					// derived fields:
+					BlockNumber: blockNumber.Uint64(),
+					TxHash:      txs[4].Hash(),
+					TxIndex:     4,
+					BlockHash:   blockHash,
+					Index:       8,
+				},
+			},
+			// derived fields:
+			TxHash:            txs[4].Hash(),
+			GasUsed:           5,
 			EffectiveGasPrice: big.NewInt(3000),
 			BlockHash:         blockHash,
 			BlockNumber:       blockNumber,
@@ -405,7 +618,18 @@ var (
 			Type:              BlobTxType,
 			PostState:         common.Hash{6}.Bytes(),
 			CumulativeGasUsed: 21,
-			Logs:              []*Log{},
+			Logs: []*Log{
+				{
+					Address: params.AccountManagerAddress,
+					Topics:  []common.Hash{params.AuthorizedTxExecutedEventSig},
+					// derived fields:
+					BlockNumber: blockNumber.Uint64(),
+					TxHash:      txs[5].Hash(),
+					TxIndex:     5,
+					BlockHash:   blockHash,
+					Index:       9,
+				},
+			},
 			// derived fields:
 			TxHash:            txs[5].Hash(),
 			GasUsed:           6,
@@ -420,7 +644,18 @@ var (
 			Type:              BlobTxType,
 			PostState:         common.Hash{7}.Bytes(),
 			CumulativeGasUsed: 28,
-			Logs:              []*Log{},
+			Logs: []*Log{
+				{
+					Address: params.AccountManagerAddress,
+					Topics:  []common.Hash{params.AuthorizedTxExecutedEventSig},
+					// derived fields:
+					BlockNumber: blockNumber.Uint64(),
+					TxHash:      txs[6].Hash(),
+					TxIndex:     6,
+					BlockHash:   blockHash,
+					Index:       10,
+				},
+			},
 			// derived fields:
 			TxHash:            txs[6].Hash(),
 			GasUsed:           7,
@@ -445,44 +680,32 @@ func TestDecodeEmptyTypedReceipt(t *testing.T) {
 
 // Tests that receipt data can be correctly derived from the contextual infos
 func TestDeriveFields(t *testing.T) {
-	// Re-derive receipts.
-	basefee := big.NewInt(1000)
-	blobGasPrice := big.NewInt(920)
-	derivedReceipts := clearComputedFieldsOnReceipts(receipts)
-	err := Receipts(derivedReceipts).DeriveFields(params.TestChainConfig, blockHash, blockNumber.Uint64(), blockTime, basefee, blobGasPrice, txs)
-	if err != nil {
-		t.Fatalf("DeriveFields(...) = %v, want <nil>", err)
-	}
+	testDeriveFields(t, receipts, params.TestChainConfig)
+}
 
-	// Check diff of receipts against derivedReceipts.
-	r1, err := json.MarshalIndent(receipts, "", "  ")
-	if err != nil {
-		t.Fatal("error marshaling input receipts:", err)
-	}
-
-	r2, err := json.MarshalIndent(derivedReceipts, "", "  ")
-	if err != nil {
-		t.Fatal("error marshaling derived receipts:", err)
-	}
-	d := diff.Diff(string(r1), string(r2))
-	if d != "" {
-		t.Fatal("receipts differ:", d)
-	}
+// Tests that receipt data can be correctly derived for non-authorized accounts in Anzeon.
+func TestDeriveFieldsAnzeon(t *testing.T) {
+	testDeriveFields(t, anzeonReceipts, params.TestWBFTChainConfig)
 }
 
 // Tests that receipt data can be correctly derived for authorized accounts
 func TestDeriveFieldsAuthorizedAccount(t *testing.T) {
+	testDeriveFields(t, authorizedReceipts, params.TestWBFTChainConfig)
+}
+
+func testDeriveFields(t *testing.T, rs Receipts, chainConfig *params.ChainConfig) {
 	// Re-derive receipts.
 	basefee := big.NewInt(1000)
 	blobGasPrice := big.NewInt(920)
-	derivedReceipts := clearComputedFieldsOnReceipts(authorizedReceipts)
-	err := Receipts(derivedReceipts).DeriveFields(params.TestChainConfig, blockHash, blockNumber.Uint64(), blockTime, basefee, blobGasPrice, txs)
+	headerGasTip := big.NewInt(500)
+	derivedReceipts := clearComputedFieldsOnReceipts(rs)
+	err := Receipts(derivedReceipts).DeriveFields(chainConfig, blockHash, blockNumber.Uint64(), blockTime, basefee, headerGasTip, blobGasPrice, txs)
 	if err != nil {
 		t.Fatalf("DeriveFields(...) = %v, want <nil>", err)
 	}
 
 	// Check diff of receipts against derivedReceipts.
-	r1, err := json.MarshalIndent(authorizedReceipts, "", "  ")
+	r1, err := json.MarshalIndent(rs, "", "  ")
 	if err != nil {
 		t.Fatal("error marshaling input receipts:", err)
 	}
@@ -673,7 +896,8 @@ func clearComputedFieldsOnReceipt(receipt *Receipt) *Receipt {
 	cpy.ContractAddress = common.Address{0xff, 0xff, 0x33}
 	cpy.GasUsed = 0xffffffff
 	cpy.Logs = clearComputedFieldsOnLogs(receipt.Logs)
-	cpy.EffectiveGasPrice = big.NewInt(0)
+	// DeriveFields always sets this; nil simulates snap sync for Anzeon.
+	cpy.EffectiveGasPrice = nil
 	cpy.BlobGasUsed = 0
 	cpy.BlobGasPrice = nil
 	return &cpy

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -220,5 +220,5 @@ var (
 	AccountManagerAddress    = common.BytesToAddress([]byte{0xb0, 0x00, 0x03}) // 0x0000000000000000000000000000000000B00003
 
 	TransferEventSig             = common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef") // crypto.Keccak256Hash([]byte("Transfer(address,address,uint256)"))
-	AuthorizedTxExecutedEventSig = common.HexToHash("0x021194ea5037e1550492d0e7d285ec602bb8b6c4a0419069fa0b13579c1940c9") // crypto.Keccak256Hash([]byte("AuthorizedTxExecuted(address)"))
+	AuthorizedTxExecutedEventSig = common.HexToHash("0x40e728a89c7f5b192cf1c1b747fb64d51d81c7a2b3ed4607b94d3a1e6a3e0373") // crypto.Keccak256Hash([]byte("AuthorizedTxExecuted()"))
 )

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -219,5 +219,6 @@ var (
 	NativeCoinManagerAddress = common.BytesToAddress([]byte{0xb0, 0x00, 0x02}) // 0x0000000000000000000000000000000000B00002
 	AccountManagerAddress    = common.BytesToAddress([]byte{0xb0, 0x00, 0x03}) // 0x0000000000000000000000000000000000B00003
 
-	TransferEventSig = common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef") // crypto.Keccak256Hash([]byte("Transfer(address,address,uint256)"))
+	TransferEventSig             = common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef") // crypto.Keccak256Hash([]byte("Transfer(address,address,uint256)"))
+	AuthorizedTxExecutedEventSig = common.HexToHash("0x021194ea5037e1550492d0e7d285ec602bb8b6c4a0419069fa0b13579c1940c9") // crypto.Keccak256Hash([]byte("AuthorizedTxExecuted(address)"))
 )


### PR DESCRIPTION
### Background

In Anzeon, `effectiveGasPrice` is stored alongside the receipt in the database.
However, receipts received via snap sync are RLP-encoded, which does not include `effectiveGasPrice`, resulting in a missing value.
The previous `DeriveFields` logic had no way to recompute it correctly for Anzeon without access to state.

### Solution

**1. Emit `AuthorizedTxExecuted` event log (`state_transition.go`)**

At the end of `TransitionDb`, emit an `AuthorizedTxExecuted` event log for authorized account transactions.
This log is always added last, allowing `DeriveFields` to determine authorized account status from the receipt logs alone, without state access.

**2. Fill nil `effectiveGasPrice` in `DeriveFields` (`receipt.go`)**

Added `headerGasTip` parameter to `DeriveFields`.
When `effectiveGasPrice` is nil in Anzeon, recompute it by checking the last log of the receipt for the `AuthorizedTxExecuted` event and applying the appropriate gas tip cap.

### Changes

- `params`: Add `AuthorizedTxExecutedEventSig` event signature constant
- `core/state_transition`: Emit `AuthorizedTxExecuted` log for authorized accounts at end of `TransitionDb`
- `core/types/receipt`: Add `headerGasTip` param to `DeriveFields`; fill nil `effectiveGasPrice` for Anzeon; add `hasAuthorizedTxLog` helper