### PR TITLE
feat: support eth_GetReceiptsByHash (#167)

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1013,8 +1013,8 @@ func (api *BlockChainAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rp
 	return result, nil
 }
 
-func (s *BlockChainAPI) GetReceiptsByHash(ctx context.Context, blockHash common.Hash) ([]map[string]interface{}, error) {
-	return s.GetBlockReceipts(ctx, rpc.BlockNumberOrHashWithHash(blockHash, true))
+func (api *BlockChainAPI) GetReceiptsByHash(ctx context.Context, blockHash common.Hash) ([]map[string]interface{}, error) {
+	return api.GetBlockReceipts(ctx, rpc.BlockNumberOrHashWithHash(blockHash, true))
 }
 
 // OverrideAccount indicates the overriding fields of account during the execution

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1013,6 +1013,10 @@ func (api *BlockChainAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rp
 	return result, nil
 }
 
+func (s *BlockChainAPI) GetReceiptsByHash(ctx context.Context, blockHash common.Hash) ([]map[string]interface{}, error) {
+	return s.GetBlockReceipts(ctx, rpc.BlockNumberOrHashWithHash(blockHash, true))
+}
+
 // OverrideAccount indicates the overriding fields of account during the execution
 // of a message call.
 // Note, state and stateDiff can't be specified at the same time. If state is

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1013,6 +1013,9 @@ func (api *BlockChainAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rp
 	return result, nil
 }
 
+// GetReceiptsByHash returns all transaction receipts for the canonical block
+// identified by the given block hash. Unlike GetBlockReceipts, this method
+// only accepts a block hash and requires the block to be on the canonical chain.
 func (api *BlockChainAPI) GetReceiptsByHash(ctx context.Context, blockHash common.Hash) ([]map[string]interface{}, error) {
 	return api.GetBlockReceipts(ctx, rpc.BlockNumberOrHashWithHash(blockHash, true))
 }


### PR DESCRIPTION
## Summary
Backport of go-wbft PR #167.
This change implements the eth_GetReceiptsByHash RPC method in internal/ethapi, allowing users to retrieve all transaction receipts for a specific block identified by its hash.

## Background
While users could previously retrieve receipts using block numbers, providing a hash-based retrieval method improves the developer experience and ensures consistency with standard Ethereum JSON-RPC capabilities.

## Upstream References
Reference | Description
-- | --
wemixarchive/go-wbft#167 | support eth_GetReceiptsByHash in WBFT engine

## Changes
Add GetReceiptsByHash method: Implemented in internal/ethapi/api.go.

## Notes
(cherry picked from commit 8d757e95822940375adc4f7af958d4a24c23869b)