### PR TITLE
fix: sync Account.Extra with GovCouncil contract slots on genesis init

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -237,17 +237,22 @@ func validateAnzeonGenesisConfig(config *params.ChainConfig) error {
 	return nil
 }
 
+// initializeAnzeonGenesis sets up the Anzeon-specific genesis state by
+// creating initial WBFT extra data and injecting system contracts.
 func initializeAnzeonGenesis(genesis *Genesis) error {
 	if genesis == nil || genesis.Config == nil || !genesis.Config.AnzeonEnabled() {
 		return nil
 	}
+
 	extraData, err := wbft.CreateInitialExtraData(genesis.Config.Anzeon)
 	if err != nil {
 		return err
 	}
 	genesis.ExtraData = extraData
 
-	// Validate Extra bits in all alloc entries
+	// Validate alloc Extra bits before system contract initialization.
+	// InjectContracts does not validate because it only sets defined bits
+	// and is also called from upgrade paths where alloc is nil.
 	for addr, account := range genesis.Alloc {
 		if err := types.ValidateExtra(account.Extra); err != nil {
 			return fmt.Errorf("invalid account extra at %s: %w", addr.Hex(), err)

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -246,6 +246,14 @@ func initializeAnzeonGenesis(genesis *Genesis) error {
 		return err
 	}
 	genesis.ExtraData = extraData
+
+	// Validate Extra bits in all alloc entries
+	for addr, account := range genesis.Alloc {
+		if err := types.ValidateExtra(account.Extra); err != nil {
+			return fmt.Errorf("invalid account extra at %s: %w", addr.Hex(), err)
+		}
+	}
+
 	return InjectContracts(genesis, genesis.Config)
 }
 

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -791,6 +791,7 @@ func decodePrealloc(data string) types.GenesisAlloc {
 				Key common.Hash
 				Val common.Hash
 			}
+			Extra *uint64 `rlp:"optional"`
 		} `rlp:"optional"`
 	}
 	if err := rlp.NewStream(strings.NewReader(data), 0).Decode(&p); err != nil {
@@ -806,6 +807,10 @@ func decodePrealloc(data string) types.GenesisAlloc {
 			acc.Storage = make(map[common.Hash]common.Hash)
 			for _, slot := range account.Misc.Slots {
 				acc.Storage[slot.Key] = slot.Val
+			}
+
+			if account.Misc.Extra != nil {
+				acc.Extra = *account.Misc.Extra
 			}
 		}
 		ga[common.BigToAddress(account.Addr)] = acc

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -720,6 +720,12 @@ func TestGenesisBlock() *Genesis {
 
 // InjectContracts sets WBFT SystemContracts to genesis
 func InjectContracts(genesis *Genesis, config *params.ChainConfig) error {
+	// Ensure Alloc is initialized before passing to GetSystemContractsTransition,
+	// which may write to it during system contract initialization.
+	if genesis.Alloc == nil {
+		genesis.Alloc = make(types.GenesisAlloc)
+	}
+
 	// Anzeon baseline contracts (v1)
 	transition, err := systemcontracts.GetSystemContractsTransition(config.Anzeon.SystemContracts, &genesis.Alloc)
 	if err != nil {
@@ -727,9 +733,6 @@ func InjectContracts(genesis *Genesis, config *params.ChainConfig) error {
 	}
 	if transition == nil {
 		return errors.New("Some or all of the Anzeon parameters are missing from the genesis configuration.")
-	}
-	if genesis.Alloc == nil {
-		genesis.Alloc = map[common.Address]types.Account{}
 	}
 	for _, c := range transition.Codes {
 		genesis.Alloc[c.Address] = types.Account{Code: hexutil.MustDecode(c.Code), Balance: common.Big0, Storage: make(map[common.Hash]common.Hash)}

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -19,6 +19,7 @@ package core
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"os"
 	"reflect"
@@ -864,5 +865,26 @@ func TestStableNetGenesisAllocConsistency(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestInitializeAnzeonGenesis_InvalidExtraBit verifies that initializeAnzeonGenesis
+// returns an error when an alloc entry contains an undefined Extra bit.
+func TestInitializeAnzeonGenesis_InvalidExtraBit(t *testing.T) {
+	addr := common.HexToAddress("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+	genesis := &Genesis{
+		Alloc: types.GenesisAlloc{
+			addr: {Balance: big.NewInt(0), Extra: 1}, // undefined bit
+		},
+		Config: params.TestWBFTChainConfig,
+	}
+
+	want := fmt.Sprintf("invalid account extra at %s: unknown bits set in account extra: 0x%016x", addr.Hex(), uint64(1))
+	err := initializeAnzeonGenesis(genesis)
+	if err == nil {
+		t.Fatalf("want error %q, got nil", want)
+	}
+	if err.Error() != want {
+		t.Fatalf("want %q, have %q", want, err.Error())
 	}
 }

--- a/core/mkalloc.go
+++ b/core/mkalloc.go
@@ -48,6 +48,8 @@ type allocItemMisc struct {
 	Nonce uint64
 	Code  []byte
 	Slots []allocItemStorageItem
+
+	Extra *uint64 `rlp:"optional"`
 }
 
 type allocItemStorageItem struct {
@@ -59,7 +61,7 @@ func makelist(g *core.Genesis) []allocItem {
 	items := make([]allocItem, 0, len(g.Alloc))
 	for addr, account := range g.Alloc {
 		var misc *allocItemMisc
-		if len(account.Storage) > 0 || len(account.Code) > 0 || account.Nonce != 0 {
+		if len(account.Storage) > 0 || len(account.Code) > 0 || account.Nonce != 0 || account.Extra != 0 {
 			misc = &allocItemMisc{
 				Nonce: account.Nonce,
 				Code:  account.Code,
@@ -71,6 +73,9 @@ func makelist(g *core.Genesis) []allocItem {
 			slices.SortFunc(misc.Slots, func(a, b allocItemStorageItem) int {
 				return a.Key.Cmp(b.Key)
 			})
+			if account.Extra != 0 {
+				misc.Extra = &account.Extra
+			}
 		}
 		bigAddr := new(big.Int).SetBytes(addr.Bytes())
 		items = append(items, allocItem{bigAddr, account.Balance, misc})

--- a/core/types/state_account_extra.go
+++ b/core/types/state_account_extra.go
@@ -18,6 +18,8 @@
 
 package types
 
+import "fmt"
+
 // Extra field bit masks for StateAccount.
 // The Extra field is a 64-bit value where each bit can represent a specific state or property.
 //
@@ -36,6 +38,11 @@ const (
 	// AccountExtraMaskC defines the bit mask used to mark ... (bit 61)
 	// Uncomment and adjust as needed:
 	// AccountExtraMaskC uint64 = 1 << 61
+
+	// AccountExtraValidMask is the union of all defined bit masks.
+	// When adding a new bit mask, it must also be included here;
+	// otherwise ValidateExtra will reject accounts that use the new bit.
+	AccountExtraValidMask uint64 = AccountExtraMaskBlacklisted | AccountExtraMaskAuthorized
 )
 
 // ============================================================================
@@ -89,4 +96,13 @@ func SetAuthorized(extra uint64) uint64 {
 // ClearAuthorized clears the authorized bit in extra and returns the new value.
 func ClearAuthorized(extra uint64) uint64 {
 	return clearBit(extra, AccountExtraMaskAuthorized)
+}
+
+// ValidateExtra checks that no undefined bits are set in the extra value.
+// Returns an error if any bit outside AccountExtraValidMask is set.
+func ValidateExtra(extra uint64) error {
+	if extra&^AccountExtraValidMask != 0 {
+		return fmt.Errorf("unknown bits set in account extra: 0x%016x", extra)
+	}
+	return nil
 }

--- a/systemcontracts/gov_council.go
+++ b/systemcontracts/gov_council.go
@@ -18,11 +18,13 @@
 package systemcontracts
 
 import (
+	"bytes"
 	"fmt"
 	"math/big"
-	"strings"
+	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -58,43 +60,71 @@ const (
 	SLOT_GOV_COUNCIL_accountManager                      = "0x36" // AccountManager address slot
 )
 
-// initializeGovCouncil initializes the GovCouncil contract storage
-func initializeGovCouncil(govCouncilAddress common.Address, param map[string]string) ([]params.StateParam, error) {
+// initializeGovCouncil initializes the GovCouncil contract storage.
+// Reconciles blacklist and authorized account addresses from two sources:
+// params (chain config) and alloc.Extra bits (genesis account state).
+// The final sets are the union of both sources, applied to both alloc.Extra
+// and the contract storage slots.
+func initializeGovCouncil(govCouncilAddress common.Address, param map[string]string, alloc *types.GenesisAlloc) ([]params.StateParam, error) {
 	// Initialize GovBase first
 	sp, err := initializeBase(govCouncilAddress, param)
 	if err != nil {
 		return sp, err
 	}
 
-	// Initialize blacklist if provided
-	if blacklistStr, ok := param[GOV_COUNCIL_PARAM_BLACKLIST]; ok && blacklistStr != "" {
-		blacklistAddresses := splitAndTrim(blacklistStr, ",")
-		blacklistParams, err := initializeAddressSet(
+	// Build initial sets from params.
+	blacklistSet, err := parseParamAddresses(param[GOV_COUNCIL_PARAM_BLACKLIST])
+	if err != nil {
+		return nil, fmt.Errorf("`systemContracts.govCouncil.params.blacklist`: %w", err)
+	}
+	authorizedSet, err := parseParamAddresses(param[GOV_COUNCIL_PARAM_AUTHORIZED_ACCOUNTS])
+	if err != nil {
+		return nil, fmt.Errorf("`systemContracts.govCouncil.params.authorizedAccounts`: %w", err)
+	}
+
+	if alloc != nil {
+		// Merge Extra bits from alloc into the sets (union with params).
+		for addr, account := range *alloc {
+			if types.IsBlacklisted(account.Extra) {
+				blacklistSet[addr] = struct{}{}
+			}
+			if types.IsAuthorized(account.Extra) {
+				authorizedSet[addr] = struct{}{}
+			}
+		}
+
+		// Sync alloc.Extra bits to reflect the final merged sets.
+		// Addresses present only in params are added as new alloc entries.
+		for addr := range blacklistSet {
+			account := (*alloc)[addr]
+			account.Extra = types.SetBlacklisted(account.Extra)
+			(*alloc)[addr] = account
+		}
+		for addr := range authorizedSet {
+			account := (*alloc)[addr]
+			account.Extra = types.SetAuthorized(account.Extra)
+			(*alloc)[addr] = account
+		}
+	}
+
+	// Skip slot initialization for empty sets to avoid writing a zero-length
+	// array entry to contract storage unnecessarily.
+	if len(blacklistSet) > 0 {
+		blacklistParams := initializeAddressSet(
 			govCouncilAddress,
 			common.HexToHash(SLOT_GOV_COUNCIL_currentBlacklist_values),
 			common.HexToHash(SLOT_GOV_COUNCIL_currentBlacklist_positions),
-			blacklistAddresses,
-			"blacklist",
+			blacklistSet,
 		)
-		if err != nil {
-			return nil, fmt.Errorf("`systemContracts.govCouncil.params.blacklist`: %w", err)
-		}
 		sp = append(sp, blacklistParams...)
 	}
-
-	// Initialize authorized accounts if provided
-	if authorizedAccountsStr, ok := param[GOV_COUNCIL_PARAM_AUTHORIZED_ACCOUNTS]; ok && authorizedAccountsStr != "" {
-		authorizedAccountAddresses := splitAndTrim(authorizedAccountsStr, ",")
-		authorizedAccountParams, err := initializeAddressSet(
+	if len(authorizedSet) > 0 {
+		authorizedAccountParams := initializeAddressSet(
 			govCouncilAddress,
 			common.HexToHash(SLOT_GOV_COUNCIL_currentAuthorizedAccounts_values),
 			common.HexToHash(SLOT_GOV_COUNCIL_currentAuthorizedAccounts_positions),
-			authorizedAccountAddresses,
-			"authorizedAccounts",
+			authorizedSet,
 		)
-		if err != nil {
-			return nil, fmt.Errorf("`systemContracts.govCouncil.params.authorizedAccounts`: %w", err)
-		}
 		sp = append(sp, authorizedAccountParams...)
 	}
 
@@ -117,54 +147,41 @@ func initializeAddressSet(
 	contractAddress common.Address,
 	valuesSlot common.Hash,
 	positionsSlot common.Hash,
-	addresses []string,
-	setName string,
-) ([]params.StateParam, error) {
+	addresses map[common.Address]struct{},
+) []params.StateParam {
+	if len(addresses) == 0 {
+		return nil
+	}
+
+	// Sort addresses to ensure deterministic slot index assignment.
+	// Consistent ordering is required for a reproducible genesis block hash.
+	sorted := make([]common.Address, 0, len(addresses))
+	for addr := range addresses {
+		sorted = append(sorted, addr)
+	}
+	sort.Slice(sorted, func(i, j int) bool {
+		return bytes.Compare(sorted[i].Bytes(), sorted[j].Bytes()) < 0
+	})
+
 	sp := make([]params.StateParam, 0)
-
-	// Pre-validate and deduplicate addresses
-	uniqueAddresses := make([]common.Address, 0)
-	seen := make(map[common.Address]struct{})
-
-	for _, addrStr := range addresses {
-		addr := common.HexToAddress(strings.TrimSpace(addrStr))
-
-		// Validate zero address
-		if addr == (common.Address{}) {
-			return nil, fmt.Errorf("`systemContracts.govCouncil.params.%s` contains invalid zero address", setName)
-		}
-
-		// Add to slice only if not seen before (deduplication)
-		if _, exists := seen[addr]; !exists {
-			seen[addr] = struct{}{}
-			uniqueAddresses = append(uniqueAddresses, addr)
-		}
-	}
-
-	if len(uniqueAddresses) == 0 {
-		return sp, nil
-	}
 
 	// Set array length in base slot
 	sp = append(sp, params.StateParam{
 		Address: contractAddress,
 		Key:     valuesSlot,
-		Value:   common.BigToHash(big.NewInt(int64(len(uniqueAddresses)))),
+		Value:   common.BigToHash(big.NewInt(int64(len(sorted)))),
 	})
 
-	// Initialize each address in the set
-	for i, addr := range uniqueAddresses {
-		// Calculate array element slot: keccak256(valuesSlot) + index
+	for i, addr := range sorted {
+		// Array element slot: keccak256(valuesSlot) + index
 		arraySlot := CalculateDynamicSlot(valuesSlot, big.NewInt(int64(i)))
-
-		// Store address in array
 		sp = append(sp, params.StateParam{
 			Address: contractAddress,
 			Key:     arraySlot,
 			Value:   common.BytesToHash(addr.Bytes()),
 		})
 
-		// Store position mapping: positions[addr] = index + 1 (1-based)
+		// Position mapping: positions[addr] = index + 1 (1-based)
 		positionKey := CalculateMappingSlot(positionsSlot, addr)
 		sp = append(sp, params.StateParam{
 			Address: contractAddress,
@@ -173,7 +190,21 @@ func initializeAddressSet(
 		})
 	}
 
-	return sp, nil
+	return sp
+}
+
+// parseParamAddresses parses a comma-separated address string into a map set.
+// Returns an error if a zero address is encountered.
+func parseParamAddresses(paramStr string) (map[common.Address]struct{}, error) {
+	set := make(map[common.Address]struct{})
+	for _, s := range splitAndTrim(paramStr, ",") {
+		addr := common.HexToAddress(s)
+		if addr == (common.Address{}) {
+			return nil, fmt.Errorf("contains invalid zero address")
+		}
+		set[addr] = struct{}{}
+	}
+	return set, nil
 }
 
 // IsBlacklisted checks if an address is in the blacklist

--- a/systemcontracts/gov_council.go
+++ b/systemcontracts/gov_council.go
@@ -84,7 +84,13 @@ func initializeGovCouncil(govCouncilAddress common.Address, param map[string]str
 
 	if alloc != nil {
 		// Merge Extra bits from alloc into the sets (union with params).
+		// Zero addresses are skipped: unlike the params path which rejects them
+		// as a configuration error, a zero address in alloc may exist for other
+		// purposes and is simply not relevant to blacklist/authorized registration.
 		for addr, account := range *alloc {
+			if addr == (common.Address{}) {
+				continue
+			}
 			if types.IsBlacklisted(account.Extra) {
 				blacklistSet[addr] = struct{}{}
 			}

--- a/systemcontracts/gov_council_test.go
+++ b/systemcontracts/gov_council_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 )
@@ -62,7 +63,7 @@ func TestInitializeCouncil_EmptyLists(t *testing.T) {
 		GOV_BASE_PARAM_MEMBER_VERSION: "1",
 	}
 
-	stateParams, err := initializeGovCouncil(govCouncilAddress, params)
+	stateParams, err := initializeGovCouncil(govCouncilAddress, params, nil)
 	require.NoError(t, err)
 	require.NotNil(t, stateParams)
 
@@ -94,7 +95,7 @@ func TestInitializeCouncil_WithBlacklist(t *testing.T) {
 		GOV_COUNCIL_PARAM_BLACKLIST:   "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
 	}
 
-	stateParams, err := initializeGovCouncil(govCouncilAddress, params)
+	stateParams, err := initializeGovCouncil(govCouncilAddress, params, nil)
 	require.NoError(t, err)
 	require.NotNil(t, stateParams)
 
@@ -130,7 +131,7 @@ func TestInitializeCouncil_WithAuthorizedAccounts(t *testing.T) {
 		GOV_COUNCIL_PARAM_AUTHORIZED_ACCOUNTS: "0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD,0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE",
 	}
 
-	stateParams, err := initializeGovCouncil(govCouncilAddress, params)
+	stateParams, err := initializeGovCouncil(govCouncilAddress, params, nil)
 	require.NoError(t, err)
 	require.NotNil(t, stateParams)
 
@@ -167,7 +168,7 @@ func TestInitializeCouncil_WithBothLists(t *testing.T) {
 		GOV_COUNCIL_PARAM_AUTHORIZED_ACCOUNTS: "0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD",
 	}
 
-	stateParams, err := initializeGovCouncil(govCouncilAddress, params)
+	stateParams, err := initializeGovCouncil(govCouncilAddress, params, nil)
 	require.NoError(t, err)
 	require.NotNil(t, stateParams)
 
@@ -199,7 +200,7 @@ func TestInitializeCouncil_DuplicateAddresses(t *testing.T) {
 		GOV_COUNCIL_PARAM_BLACKLIST: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
 	}
 
-	stateParams, err := initializeGovCouncil(govCouncilAddress, params)
+	stateParams, err := initializeGovCouncil(govCouncilAddress, params, nil)
 	require.NoError(t, err)
 
 	// Apply state params to mock state
@@ -223,7 +224,7 @@ func TestInitializeCouncil_ZeroAddressError(t *testing.T) {
 		GOV_COUNCIL_PARAM_BLACKLIST:   "0x0000000000000000000000000000000000000000",
 	}
 
-	_, err := initializeGovCouncil(govCouncilAddress, params)
+	_, err := initializeGovCouncil(govCouncilAddress, params, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "zero address")
 }
@@ -238,7 +239,7 @@ func TestGetAllBlacklisted(t *testing.T) {
 		GOV_COUNCIL_PARAM_BLACKLIST:   "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB,0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
 	}
 
-	stateParams, err := initializeGovCouncil(govCouncilAddress, params)
+	stateParams, err := initializeGovCouncil(govCouncilAddress, params, nil)
 	require.NoError(t, err)
 
 	// Apply state params to mock state
@@ -267,7 +268,7 @@ func TestGetAllAuthorizedAccounts(t *testing.T) {
 		GOV_COUNCIL_PARAM_AUTHORIZED_ACCOUNTS: "0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD,0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE",
 	}
 
-	stateParams, err := initializeGovCouncil(govCouncilAddress, params)
+	stateParams, err := initializeGovCouncil(govCouncilAddress, params, nil)
 	require.NoError(t, err)
 
 	// Apply state params to mock state
@@ -305,13 +306,10 @@ func TestInitializeAddressSet_StorageLayout(t *testing.T) {
 	contractAddress := common.HexToAddress("0x1000")
 	valuesSlot := common.HexToHash(SLOT_GOV_COUNCIL_currentBlacklist_values)
 	positionsSlot := common.HexToHash(SLOT_GOV_COUNCIL_currentBlacklist_positions)
-	addresses := []string{
-		"0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-		"0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-	}
-
-	stateParams, err := initializeAddressSet(contractAddress, valuesSlot, positionsSlot, addresses, "test")
+	addresses, err := parseParamAddresses("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB")
 	require.NoError(t, err)
+
+	stateParams := initializeAddressSet(contractAddress, valuesSlot, positionsSlot, addresses)
 	require.NotNil(t, stateParams)
 
 	// Apply to mock state
@@ -348,24 +346,22 @@ func TestInitializeAddressSet_EmptyList(t *testing.T) {
 	contractAddress := common.HexToAddress("0x1000")
 	valuesSlot := common.HexToHash(SLOT_GOV_COUNCIL_currentBlacklist_values)
 	positionsSlot := common.HexToHash(SLOT_GOV_COUNCIL_currentBlacklist_positions)
-	addresses := []string{}
-
-	stateParams, err := initializeAddressSet(contractAddress, valuesSlot, positionsSlot, addresses, "test")
+	addresses, err := parseParamAddresses("")
 	require.NoError(t, err)
-	require.Empty(t, stateParams, "Empty list should not generate state params")
+
+	stateParams := initializeAddressSet(contractAddress, valuesSlot, positionsSlot, addresses)
+	require.Empty(t, stateParams, "Empty map should not generate state params")
 }
 
 func TestInitializeAddressSet_WithWhitespace(t *testing.T) {
 	contractAddress := common.HexToAddress("0x1000")
 	valuesSlot := common.HexToHash(SLOT_GOV_COUNCIL_currentBlacklist_values)
 	positionsSlot := common.HexToHash(SLOT_GOV_COUNCIL_currentBlacklist_positions)
-	addresses := []string{
-		"  0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA  ",
-		"\t0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB\n",
-	}
 
-	stateParams, err := initializeAddressSet(contractAddress, valuesSlot, positionsSlot, addresses, "test")
+	addresses, err := parseParamAddresses("  0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA  ,\t0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB\n")
 	require.NoError(t, err)
+
+	stateParams := initializeAddressSet(contractAddress, valuesSlot, positionsSlot, addresses)
 
 	// Apply to mock state
 	mockState := NewMockStateReader()
@@ -388,7 +384,7 @@ func TestInitializeCouncil_AccountManagerInitialization(t *testing.T) {
 		GOV_BASE_PARAM_MEMBER_VERSION: "1",
 	}
 
-	stateParams, err := initializeGovCouncil(govCouncilAddress, testParams)
+	stateParams, err := initializeGovCouncil(govCouncilAddress, testParams, nil)
 	require.NoError(t, err)
 	require.NotNil(t, stateParams)
 
@@ -423,7 +419,7 @@ func TestInitializeCouncil_AllSlots(t *testing.T) {
 		GOV_COUNCIL_PARAM_AUTHORIZED_ACCOUNTS: "0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD",
 	}
 
-	stateParams, err := initializeGovCouncil(govCouncilAddress, testParams)
+	stateParams, err := initializeGovCouncil(govCouncilAddress, testParams, nil)
 	require.NoError(t, err)
 	require.NotNil(t, stateParams)
 
@@ -452,4 +448,170 @@ func TestInitializeCouncil_AllSlots(t *testing.T) {
 	accountManagerValue := mockState.GetState(govCouncilAddress, accountManagerSlot)
 	storedAddress := common.BytesToAddress(accountManagerValue.Bytes())
 	require.Equal(t, params.AccountManagerAddress, storedAddress)
+}
+
+// ==================== Alloc Sync Tests ====================
+
+var (
+	govCouncilSyncTestAddress = common.HexToAddress("0x1000")
+	syncTestParam             = map[string]string{
+		GOV_BASE_PARAM_MEMBERS:        "0x1111111111111111111111111111111111111111",
+		GOV_BASE_PARAM_QUORUM:         "1",
+		GOV_BASE_PARAM_EXPIRY:         "604800",
+		GOV_BASE_PARAM_MEMBER_VERSION: "1",
+	}
+
+	addrA = common.HexToAddress("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+	addrB = common.HexToAddress("0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB")
+	addrC = common.HexToAddress("0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC")
+)
+
+// applyToMockState applies StateParams to a MockStateReader for verification.
+func applyToMockState(stateParams []params.StateParam) *MockStateReader {
+	mockState := NewMockStateReader()
+	for _, p := range stateParams {
+		mockState.SetState(p.Address, p.Key, p.Value)
+	}
+	return mockState
+}
+
+// TestAllocSync_ParamsOnly verifies that addresses in params but not in alloc
+// are registered in contract slots and added as new alloc entries with correct Extra bits.
+func TestAllocSync_ParamsOnly(t *testing.T) {
+	param := copyMap(syncTestParam)
+	param[GOV_COUNCIL_PARAM_BLACKLIST] = addrA.Hex()
+	param[GOV_COUNCIL_PARAM_AUTHORIZED_ACCOUNTS] = addrB.Hex()
+
+	alloc := make(types.GenesisAlloc)
+	stateParams, err := initializeGovCouncil(govCouncilSyncTestAddress, param, &alloc)
+	require.NoError(t, err)
+
+	// Contract slots reflect params addresses.
+	mockState := applyToMockState(stateParams)
+	require.True(t, IsBlacklisted(govCouncilSyncTestAddress, mockState, addrA))
+	require.True(t, IsAuthorizedAccount(govCouncilSyncTestAddress, mockState, addrB))
+
+	// New alloc entries are created with correct Extra bits.
+	require.True(t, types.IsBlacklisted(alloc[addrA].Extra))
+	require.True(t, types.IsAuthorized(alloc[addrB].Extra))
+}
+
+// TestAllocSync_AllocOnly verifies that addresses with Extra bits set in alloc
+// but absent from params are registered in contract slots.
+func TestAllocSync_AllocOnly(t *testing.T) {
+	param := copyMap(syncTestParam)
+
+	alloc := types.GenesisAlloc{
+		addrA: {Balance: big.NewInt(0), Extra: types.SetBlacklisted(0)},
+		addrB: {Balance: big.NewInt(0), Extra: types.SetAuthorized(0)},
+	}
+	stateParams, err := initializeGovCouncil(govCouncilSyncTestAddress, param, &alloc)
+	require.NoError(t, err)
+
+	// Contract slots reflect alloc.Extra addresses.
+	mockState := applyToMockState(stateParams)
+	require.True(t, IsBlacklisted(govCouncilSyncTestAddress, mockState, addrA))
+	require.True(t, IsAuthorizedAccount(govCouncilSyncTestAddress, mockState, addrB))
+}
+
+// TestAllocSync_Union verifies that addresses from both params and alloc.Extra
+// are merged into the final set without duplication.
+func TestAllocSync_Union(t *testing.T) {
+	param := copyMap(syncTestParam)
+	param[GOV_COUNCIL_PARAM_BLACKLIST] = addrA.Hex()
+
+	alloc := types.GenesisAlloc{
+		addrB: {Balance: big.NewInt(0), Extra: types.SetBlacklisted(0)},
+	}
+	stateParams, err := initializeGovCouncil(govCouncilSyncTestAddress, param, &alloc)
+	require.NoError(t, err)
+
+	// Both addresses appear in contract slots.
+	mockState := applyToMockState(stateParams)
+	require.True(t, IsBlacklisted(govCouncilSyncTestAddress, mockState, addrA))
+	require.True(t, IsBlacklisted(govCouncilSyncTestAddress, mockState, addrB))
+	require.Equal(t, big.NewInt(2), GetBlacklistCount(govCouncilSyncTestAddress, mockState))
+}
+
+// TestAllocSync_NoDuplication verifies that an address present in both params and alloc.Extra
+// appears only once in the contract slots.
+func TestAllocSync_NoDuplication(t *testing.T) {
+	param := copyMap(syncTestParam)
+	param[GOV_COUNCIL_PARAM_BLACKLIST] = addrA.Hex()
+
+	alloc := types.GenesisAlloc{
+		addrA: {Balance: big.NewInt(0), Extra: types.SetBlacklisted(0)},
+	}
+	stateParams, err := initializeGovCouncil(govCouncilSyncTestAddress, param, &alloc)
+	require.NoError(t, err)
+
+	mockState := applyToMockState(stateParams)
+	require.Equal(t, big.NewInt(1), GetBlacklistCount(govCouncilSyncTestAddress, mockState))
+}
+
+// TestAllocSync_BothBitsSet verifies that an address with blacklist Extra bit
+// but authorized in params ends up with both bits set and registered in both slots.
+func TestAllocSync_BothBitsSet(t *testing.T) {
+	param := copyMap(syncTestParam)
+	param[GOV_COUNCIL_PARAM_AUTHORIZED_ACCOUNTS] = addrA.Hex()
+
+	alloc := types.GenesisAlloc{
+		addrA: {Balance: big.NewInt(0), Extra: types.SetBlacklisted(0)},
+	}
+	stateParams, err := initializeGovCouncil(govCouncilSyncTestAddress, param, &alloc)
+	require.NoError(t, err)
+
+	// Both bits set in alloc.Extra.
+	require.True(t, types.IsBlacklisted(alloc[addrA].Extra))
+	require.True(t, types.IsAuthorized(alloc[addrA].Extra))
+
+	// Registered in both contract slots.
+	mockState := applyToMockState(stateParams)
+	require.True(t, IsBlacklisted(govCouncilSyncTestAddress, mockState, addrA))
+	require.True(t, IsAuthorizedAccount(govCouncilSyncTestAddress, mockState, addrA))
+}
+
+// TestAllocSync_ExtraPreserved verifies that existing alloc entries with Extra bits
+// not related to blacklist/authorized are not modified.
+func TestAllocSync_ExtraPreserved(t *testing.T) {
+	param := copyMap(syncTestParam)
+	param[GOV_COUNCIL_PARAM_BLACKLIST] = addrA.Hex()
+
+	const otherBit uint64 = 0 // no valid unrelated bits yet, use zero as baseline
+	alloc := types.GenesisAlloc{
+		addrC: {Balance: big.NewInt(1000), Extra: otherBit},
+	}
+	_, err := initializeGovCouncil(govCouncilSyncTestAddress, param, &alloc)
+	require.NoError(t, err)
+
+	// addrC is untouched.
+	require.Equal(t, otherBit, alloc[addrC].Extra)
+	require.Equal(t, big.NewInt(1000), alloc[addrC].Balance)
+}
+
+// TestAllocSync_ExtraSyncedForExistingEntry verifies that an alloc entry present
+// in params but missing the Extra bit gets its Extra bit updated.
+func TestAllocSync_ExtraSyncedForExistingEntry(t *testing.T) {
+	param := copyMap(syncTestParam)
+	param[GOV_COUNCIL_PARAM_BLACKLIST] = addrA.Hex()
+
+	// addrA exists in alloc but without the blacklist Extra bit.
+	alloc := types.GenesisAlloc{
+		addrA: {Balance: big.NewInt(500)},
+	}
+	_, err := initializeGovCouncil(govCouncilSyncTestAddress, param, &alloc)
+	require.NoError(t, err)
+
+	// Extra bit is synced; Balance is preserved.
+	require.True(t, types.IsBlacklisted(alloc[addrA].Extra))
+	require.Equal(t, big.NewInt(500), alloc[addrA].Balance)
+}
+
+// copyMap returns a shallow copy of a string map.
+func copyMap(m map[string]string) map[string]string {
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
 }

--- a/systemcontracts/systemcontracts.go
+++ b/systemcontracts/systemcontracts.go
@@ -145,7 +145,7 @@ func GetSystemContractsTransition(systemContracts *params.SystemContracts, alloc
 		}
 		st.Codes = append(st.Codes, params.CodeParam{Address: systemContracts.GovCouncil.Address, Code: code})
 		if systemContracts.GovCouncil.Params != nil && systemContracts.GovCouncil.Version == SYSTEM_CONTRACT_VERSION_1 {
-			sp, err := initializeGovCouncil(systemContracts.GovCouncil.Address, systemContracts.GovCouncil.Params)
+			sp, err := initializeGovCouncil(systemContracts.GovCouncil.Address, systemContracts.GovCouncil.Params, alloc)
 			if err != nil {
 				return nil, err
 			}

--- a/systemcontracts/test/gov_council_alloc_sync_test.go
+++ b/systemcontracts/test/gov_council_alloc_sync_test.go
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2025 The go-stablenet Authors
+// This file is part of the go-stablenet library.
+//
+// The go-stablenet library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-stablenet is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-stablenet library. If not, see <http://www.gnu.org/licenses/>.
+
+package test
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	sc "github.com/ethereum/go-ethereum/systemcontracts"
+	"github.com/stretchr/testify/require"
+)
+
+// newAllocSyncEnv creates a minimal GovCouncil environment for alloc sync tests.
+// alloc entries can include Extra bits to simulate pre-existing account state.
+func newAllocSyncEnv(t *testing.T, alloc types.GenesisAlloc, blacklistParam, authorizedParam string) (*GovWBFT, *EOA) {
+	t.Helper()
+
+	members := []*TestCandidate{NewTestCandidate(), NewTestCandidate(), NewTestCandidate()}
+	nonMember := NewEOA()
+
+	for _, m := range members {
+		alloc[m.Operator.Address] = types.Account{Balance: towei(1_000_000)}
+	}
+	alloc[nonMember.Address] = types.Account{Balance: towei(1_000_000)}
+
+	var memberAddrs, validators, blsPubKeys string
+	for i, m := range members {
+		if i > 0 {
+			memberAddrs += ","
+			validators += ","
+			blsPubKeys += ","
+		}
+		memberAddrs += m.Operator.Address.String()
+		validators += m.Validator.Address.String()
+		blsPubKeys += hexutil.Encode(m.GetBLSPublicKey(t).Marshal())
+	}
+
+	govCouncil, err := NewGovWBFT(t, alloc,
+		func(v *params.SystemContract) {
+			v.Params = map[string]string{
+				"members":       memberAddrs,
+				"quorum":        "2",
+				"expiry":        "604800",
+				"memberVersion": "1",
+				"validators":    validators,
+				"blsPublicKeys": blsPubKeys,
+			}
+		},
+		nil, nil, nil,
+		func(c *params.SystemContract) {
+			c.Params = map[string]string{
+				sc.GOV_BASE_PARAM_MEMBERS:                memberAddrs,
+				sc.GOV_BASE_PARAM_QUORUM:                 "2",
+				sc.GOV_BASE_PARAM_EXPIRY:                 "604800",
+				sc.GOV_BASE_PARAM_MEMBER_VERSION:         "1",
+				sc.GOV_COUNCIL_PARAM_BLACKLIST:           blacklistParam,
+				sc.GOV_COUNCIL_PARAM_AUTHORIZED_ACCOUNTS: authorizedParam,
+			}
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	return govCouncil, nonMember
+}
+
+// TestAllocSync_ParamsOnly_Integration verifies that addresses in params but absent
+// from alloc.Extra are registered in contract slots after genesis.
+func TestAllocSync_ParamsOnly_Integration(t *testing.T) {
+	addrA := NewEOA().Address
+	addrB := NewEOA().Address
+
+	govCouncil, nonMember := newAllocSyncEnv(t, types.GenesisAlloc{}, addrA.Hex(), addrB.Hex())
+	defer govCouncil.backend.Close()
+
+	isBlacklisted, err := govCouncil.IsBlacklisted(nonMember, addrA)
+	require.NoError(t, err)
+	require.True(t, isBlacklisted)
+
+	isAuthorized, err := govCouncil.IsAuthorizedAccount(nonMember, addrB)
+	require.NoError(t, err)
+	require.True(t, isAuthorized)
+}
+
+// TestAllocSync_AllocOnly_Integration verifies that addresses with Extra bits set
+// in alloc but absent from params are registered in contract slots after genesis.
+func TestAllocSync_AllocOnly_Integration(t *testing.T) {
+	addrA := NewEOA().Address
+	addrB := NewEOA().Address
+
+	alloc := types.GenesisAlloc{
+		addrA: {Balance: big.NewInt(0), Extra: types.SetBlacklisted(0)},
+		addrB: {Balance: big.NewInt(0), Extra: types.SetAuthorized(0)},
+	}
+
+	govCouncil, nonMember := newAllocSyncEnv(t, alloc, "", "")
+	defer govCouncil.backend.Close()
+
+	isBlacklisted, err := govCouncil.IsBlacklisted(nonMember, addrA)
+	require.NoError(t, err)
+	require.True(t, isBlacklisted)
+
+	isAuthorized, err := govCouncil.IsAuthorizedAccount(nonMember, addrB)
+	require.NoError(t, err)
+	require.True(t, isAuthorized)
+}
+
+// TestAllocSync_Union_Integration verifies that addresses from both params and alloc.Extra
+// are merged into the contract slots without duplication.
+func TestAllocSync_Union_Integration(t *testing.T) {
+	addrA := NewEOA().Address
+	addrB := NewEOA().Address
+
+	alloc := types.GenesisAlloc{
+		addrB: {Balance: big.NewInt(0), Extra: types.SetBlacklisted(0)},
+	}
+
+	govCouncil, nonMember := newAllocSyncEnv(t, alloc, addrA.Hex(), "")
+	defer govCouncil.backend.Close()
+
+	count, err := govCouncil.GetBlacklistCount(nonMember)
+	require.NoError(t, err)
+	require.Equal(t, big.NewInt(2), count)
+
+	isBlacklistedA, err := govCouncil.IsBlacklisted(nonMember, addrA)
+	require.NoError(t, err)
+	require.True(t, isBlacklistedA)
+
+	isBlacklistedB, err := govCouncil.IsBlacklisted(nonMember, addrB)
+	require.NoError(t, err)
+	require.True(t, isBlacklistedB)
+}
+
+// TestAllocSync_NoDuplication_Integration verifies that an address present in both
+// params and alloc.Extra appears only once in the contract slots.
+func TestAllocSync_NoDuplication_Integration(t *testing.T) {
+	addrA := NewEOA().Address
+
+	alloc := types.GenesisAlloc{
+		addrA: {Balance: big.NewInt(0), Extra: types.SetBlacklisted(0)},
+	}
+
+	govCouncil, nonMember := newAllocSyncEnv(t, alloc, addrA.Hex(), "")
+	defer govCouncil.backend.Close()
+
+	count, err := govCouncil.GetBlacklistCount(nonMember)
+	require.NoError(t, err)
+	require.Equal(t, big.NewInt(1), count)
+}
+
+// TestAllocSync_BothBitsSet_Integration verifies that an address with blacklist Extra bit
+// but authorized in params is registered in both contract slots.
+func TestAllocSync_BothBitsSet_Integration(t *testing.T) {
+	addrA := NewEOA().Address
+
+	alloc := types.GenesisAlloc{
+		addrA: {Balance: big.NewInt(0), Extra: types.SetBlacklisted(0)},
+	}
+
+	govCouncil, nonMember := newAllocSyncEnv(t, alloc, "", addrA.Hex())
+	defer govCouncil.backend.Close()
+
+	isBlacklisted, err := govCouncil.IsBlacklisted(nonMember, addrA)
+	require.NoError(t, err)
+	require.True(t, isBlacklisted)
+
+	isAuthorized, err := govCouncil.IsAuthorizedAccount(nonMember, addrA)
+	require.NoError(t, err)
+	require.True(t, isAuthorized)
+}
+
+// TestAllocSync_UnrelatedAllocPreserved_Integration verifies that alloc entries
+// unrelated to blacklist/authorized are not affected by genesis sync.
+func TestAllocSync_UnrelatedAllocPreserved_Integration(t *testing.T) {
+	addrA := NewEOA().Address
+	addrUnrelated := NewEOA().Address
+
+	alloc := types.GenesisAlloc{
+		addrUnrelated: {Balance: towei(999)},
+	}
+
+	govCouncil, nonMember := newAllocSyncEnv(t, alloc, addrA.Hex(), "")
+	defer govCouncil.backend.Close()
+
+	// addrUnrelated is not in the blacklist.
+	isBlacklisted, err := govCouncil.IsBlacklisted(nonMember, addrUnrelated)
+	require.NoError(t, err)
+	require.False(t, isBlacklisted)
+
+	// addrA is blacklisted as expected.
+	isBlacklisted, err = govCouncil.IsBlacklisted(nonMember, addrA)
+	require.NoError(t, err)
+	require.True(t, isBlacklisted)
+
+	// Verify balance preserved via contract call (balance check through chain).
+	balance, err := govCouncil.backend.Client().BalanceAt(context.Background(), addrUnrelated, nil)
+	require.NoError(t, err)
+	require.Equal(t, towei(999), balance)
+}

--- a/systemcontracts/test/helpers_edge_cases.go
+++ b/systemcontracts/test/helpers_edge_cases.go
@@ -18,8 +18,10 @@
 package test
 
 import (
+	"bytes"
 	"fmt"
 	"math/big"
+	"sort"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -212,6 +214,15 @@ func createGovCouncilTestEnv(t *testing.T) *GovCouncilTestEnv {
 		NewEOA().Address,
 		NewEOA().Address,
 	}
+
+	// Sort to match the deterministic slot assignment order used by initializeAddressSet.
+	sortAddrs := func(addrs []common.Address) {
+		sort.Slice(addrs, func(i, j int) bool {
+			return bytes.Compare(addrs[i].Bytes(), addrs[j].Bytes()) < 0
+		})
+	}
+	sortAddrs(blacklist)
+	sortAddrs(authorizedAccounts)
 
 	// Convert address slices to comma-separated strings
 	blacklistStr := blacklist[0].Hex() + "," + blacklist[1].Hex()


### PR DESCRIPTION
## Summary

Ensure consistency between `Account.Extra` bits and GovCouncil contract storage slots (blacklist / authorized accounts) at genesis initialization.
Previously, the two sources could diverge — addresses set via chain config params were not reflected in `alloc.Extra`, and vice versa.

## Changes

### Bug Fixes
- **Alloc ↔ contract slot sync** (`systemcontracts/gov_council.go`, `systemcontracts/systemcontracts.go`)
  Pass `genesis.Alloc` to `initializeGovCouncil` and reconcile blacklist/authorized addresses from both `Account.Extra` bits and chain config params into a unified set (union).
  Both `alloc.Extra` and contract storage slots are updated to reflect the final state.

- **Nil map panic** (`core/genesis.go`)
  Initialize `genesis.Alloc` before passing to `GetSystemContractsTransition` to prevent a nil map write panic when `Alloc` is unset at the time `InjectContracts` is called.

### Additions
- **Prealloc encoding** (`core/mkalloc.go`, `core/genesis.go`)
  Include `Account.Extra` in prealloc RLP encoding/decoding (`rlp:"optional"` for backward compatibility).
  
- **Extra bit validation** (`core/types/state_account_extra.go`, `core/genesis.go`)
  Add `AccountExtraValidMask` constant and `ValidateExtra` function. 
  Reject undefined Extra bits early in `initializeAnzeonGenesis` before any initialization runs.