### PR TITLE
fix: increase txMaxSize to 256KB to align with MaxCodeSize

### DIFF
--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -257,7 +257,7 @@ func TestStateProcessorErrors(t *testing.T) {
 				txs: []*types.Transaction{
 					mkDynamicCreationTx(0, 2200000, common.Big0, big.NewInt(params.InitialBaseFee), tooBigInitCode[:]),
 				},
-				want: "could not apply tx 0 [0x69ce6254cd3a8f1c5b5027fab79ae62ab9de5e7d6297cf7101d61ad8f65d7cf4]: max initcode size exceeded: code size 507905 limit 507904",
+				want: "could not apply tx 0 [0xbd18b2276dd1d7ded4033f2670b70edba603b7f47708c708e0b47dc2ab985a6d]: max initcode size exceeded: code size 253953 limit 253952",
 			},
 			{ // ErrIntrinsicGas: Not enough gas to cover init code
 				txs: []*types.Transaction{

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -46,14 +46,15 @@ const (
 	// txSlotSize is used to calculate how many data slots a single transaction
 	// takes up based on its size. The slots are used as DoS protection, ensuring
 	// that validating a new transaction remains a constant operation (in reality
-	// O(maxslots), where max slots are 4 currently).
+	// O(maxslots), where max slots are 8 currently).
 	txSlotSize = 32 * 1024
 
 	// txMaxSize is the maximum size a single transaction can have. This field has
 	// non-trivial consequences: larger transactions are significantly harder and
 	// more expensive to propagate; larger transactions also take more resources
 	// to validate whether they fit into the pool or not.
-	txMaxSize = 4 * txSlotSize // 128KB
+	// Note: increased to 256KB (8 slots) in go-stablenet to accommodate the larger MaxCodeSize (248KB).
+	txMaxSize = 8 * txSlotSize // 256KB
 )
 
 var (

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -137,8 +137,8 @@ const (
 
 	InitialGasTip uint64 = 27600000000000 // Initial gas tip
 
-	MaxCodeSize     = 253952          // WEMIX Maximum bytecode to permit for a contract
-	MaxInitCodeSize = 2 * MaxCodeSize // Maximum initcode to permit in a creation transaction and create instructions
+	MaxCodeSize     = 253952      // WEMIX Maximum bytecode to permit for a contract
+	MaxInitCodeSize = MaxCodeSize // Maximum initcode to permit in a creation transaction and create instructions
 
 	// Precompiled contract gas prices
 


### PR DESCRIPTION
## Summary

### Background
In go-stablenet, `MaxCodeSize` was previously increased from 24 KB to 248 KB to support larger smart contracts. 
Since `MaxInitCodeSize` was defined as `2 * MaxCodeSize`, it automatically became 496 KB.

### Problem
`txMaxSize` in `legacypool` was not updated and remained at 128 KB (4 slots).
This caused contract deployment transactions exceeding txMaxSize (128 KB) to be **rejected at the txpool level**, making the expanded `MaxCodeSize` effectively unusable. 

## Changes

- **`params/protocol_params.go`**
  - `MaxInitCodeSize`: `2 * MaxCodeSize` (496 KB) → `MaxCodeSize` (248 KB)
    - Allowing init code up to 2x MaxCodeSize (496 KB) is unnecessary;
      MaxCodeSize (248 KB) is sufficient for deployment transactions.

- **`core/txpool/legacypool/legacypool.go`**
  - `txMaxSize`: `4 * txSlotSize` (128 KB) → `8 * txSlotSize` (256 KB)

## Resolved

- **Contract Deployment**: Transactions with up to 248 KB of init code are now correctly accepted into the txpool legacy pool.
- **Validation Logic**: The `MaxInitCodeSize` check in `txpool/validation.go` is now reachable and functional as  `txMaxSize` (256 KB) is properly aligned to be greater than `MaxInitCodeSize` (248 KB).