### PR TITLE
fix: refresh AnzeonTipEnv current block when GasTip changes

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -2055,10 +2055,17 @@ func (t *lookup) RemoteToLocals(locals *accountSet) int {
 }
 
 // RemotesBelowTip finds all remote transactions below the given tip threshold.
+// For unauthorized accounts, AnzeonTipCap is cached at pool entry time as block.GasTip(),
+// which is the actual effective tip used during execution. If that cached value is below
+// the threshold, the tx is dropped even when tx.GasTipCap() is above it.
 func (t *lookup) RemotesBelowTip(threshold *big.Int) types.Transactions {
 	found := make(types.Transactions, 0, 128)
 	t.Range(func(hash common.Hash, tx *types.Transaction, local bool) bool {
-		if tx.GasTipCapIntCmp(threshold) < 0 {
+		tipcap := tx.GetAnzeonTipCap()
+		if tipcap == nil {
+			tipcap = tx.GasTipCap()
+		}
+		if tipcap.Cmp(threshold) < 0 {
 			found = append(found, tx)
 		}
 		return true

--- a/eth/gasprice/anzeon.go
+++ b/eth/gasprice/anzeon.go
@@ -47,11 +47,14 @@ func NewAnzeonTipEnv(config *params.ChainConfig, stateAt func(common.Hash) (*sta
 
 // SetCurrentBlock updates the current block header and signer.
 // This should be called when the blockchain head changes.
+// The block is refreshed if the state root or the GasTip value changes.
+// GasTip must be checked separately because empty blocks share the same root
+// as the governance-change block but carry the updated GasTip in their header.
 func (env *AnzeonTipEnv) SetCurrentBlock(header *types.Header) {
 	if header == nil {
 		return
 	}
-	if env.currentBlock == nil || env.currentBlock.Root != header.Root {
+	if env.currentBlock == nil || env.currentBlock.Root != header.Root || gasTipChanged(env.currentBlock.GasTip(), header.GasTip()) {
 		env.currentBlock = header
 		if header.Root != (common.Hash{}) {
 			env.currentState, _ = env.stateAt(header.Root)
@@ -82,6 +85,17 @@ func (env *AnzeonTipEnv) GetBaseFee() *big.Int {
 		return env.currentBlock.BaseFee
 	}
 	return nil
+}
+
+// gasTipChanged reports whether two GasTip values differ.
+func gasTipChanged(a, b *big.Int) bool {
+	if a == nil && b == nil {
+		return false
+	}
+	if a == nil || b == nil {
+		return true
+	}
+	return a.Cmp(b) != 0
 }
 
 // GetAnzeonTipCap returns the effective gas tip cap for a transaction in the Anzeon network.


### PR DESCRIPTION
### Summary
- Fix `AnzeonTipEnv.SetCurrentBlock()` not refreshing `currentBlock` on empty blocks after a governance `GasTip` change (due to state root equality check only)
- Fix `RemotesBelowTip()` comparing `tx.GasTipCap()` instead of cached `AnzeonTipCap`, causing unauthorized transactions to remain in the pool even when they can never meet `minTip`

---

### Background

#### 1. AnzeonTipEnv: stale currentBlock

- **Root cause**
  - `GasTip` in a block header is derived from the **parent block state**
  - A governance change at block **N** is only reflected in block **N+1**

- **Problem scenario**
  - Block **N+1** is an **empty block**
  - State root remains unchanged from block **N**
  - `SetCurrentBlock()` skips update (`Root != header.Root` is false)

- **Impact**
  - `currentBlock` remains at block **N** (pre-change `GasTip`)
  - `GetAnzeonTipCap()` returns stale `GasTip`
  - `EffectiveGasTip < minTip (updated)`
  - → Transaction is **never included in a block**

---

#### 2. RemotesBelowTip: incorrect tip comparison

- **Root cause**
  - For unauthorized accounts:
    - `AnzeonTipCap` is cached at pool entry (`block.GasTip()`)
    - → this is the **actual effective tip used during execution**

- **Problem**
  - `RemotesBelowTip()` compares only `tx.GasTipCap()` with threshold

- **Impact**
  - When `minTip` increases:
    - `GasTipCap` ≥ threshold ✅
    - `AnzeonTipCap` < threshold ❌
  - → Transaction:
    - is **not dropped from pool**
    - is **never included in a block**

→ Result: **stuck (dead) transactions remain in the pool**

---

### Changes
- `AnzeonTipEnv.SetCurrentBlock()`
  - Add `GasTip` comparison (`gasTipChanged()`) in addition to state root check
  - → Ensures `currentBlock` is refreshed even when root is unchanged (e.g. empty blocks)

- `RemotesBelowTip()`
  - Use cached `AnzeonTipCap` instead of `tx.GasTipCap()`
  - Fallback to `GasTipCap()` if cache is missing
  - → Drop decision is based on **actual effective tip**