### PR TITLE
ci: add master-ci workflow

### DIFF
--- a/.github/workflows/master-ci.yml
+++ b/.github/workflows/master-ci.yml
@@ -1,0 +1,57 @@
+name: master-ci
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build_test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.23.12
+
+      - name: Build StableNet
+        run: make gstable
+
+  lint_test:
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [1.23.12]
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.version }}
+
+      - name: Check Lint
+        run: make lint
+
+  unit_test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'true'
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.23.12
+
+      - name: Check golang Test Cases
+        run: make test-short


### PR DESCRIPTION
## Summary

  Add `.github/workflows/master-ci.yml` to run CI checks on pull requests targeting `master`.

  ## Jobs

  | Job | Description |                                                                                                                                                                                   
  |---|---|
  | `build_test` | Build check via `make gstable` |                                                                                                                                                       
  | `lint_test` | Lint check via `make lint` |
  | `unit_test` | Unit test via `make test-short` |