### PR TITLE
fix: race conditions in newRoundChangeTimer

### DIFF
--- a/consensus/wbft/core/core.go
+++ b/consensus/wbft/core/core.go
@@ -258,8 +258,15 @@ func (c *Core) startNewRound(round *big.Int) {
 	c.backend.NotifyNewRound(round)
 
 	// the order of NotifyNewRound() and newRoundChangeTimer() does not matter on actual consensus, but
-	// it matters on multi-engine test, so we keep the order as it is
-	c.newRoundChangeTimer()
+	// it matters on multi-engine test, so we keep the order as it is.
+	//
+	// currentMutex.Lock() is held here (see top of startNewRound); snapshot the
+	// view fields directly and pass them to newRoundChangeTimer, which no
+	// longer touches c.current.
+	c.newRoundChangeTimer(
+		new(big.Int).Set(c.current.Sequence()),
+		new(big.Int).Set(c.current.Round()),
+	)
 
 	oldLogger.Info("WBFT: start new round", "next.round", newView.Round, "next.seq", newView.Sequence, "next.proposer", c.valSet.GetProposer(), "next.valSet", c.valSet.List(), "next.size", c.valSet.Size(), "next.IsProposer", c.IsProposer())
 }
@@ -337,18 +344,26 @@ func (c *Core) stopTimer() {
 	c.cancelLastSentTimeout()
 }
 
-func (c *Core) newRoundChangeTimer() {
+// newRoundChangeTimer schedules a ROUND-CHANGE timer for the given view.
+// The caller is responsible for snapshotting seq and round under currentMutex
+// before calling; this function does not read c.current.
+//
+// If seq or round is nil, the function stops any prior timer and returns
+// without scheduling a new one.
+func (c *Core) newRoundChangeTimer(seq, round *big.Int) {
 	c.stopTimer()
 
-	for c.current == nil { // wait because it is asynchronous in handleRequest
-		time.Sleep(10 * time.Millisecond)
+	if seq == nil || round == nil {
+		c.logger.Warn("WBFT: newRoundChangeTimer skipped: current view not initialized")
+		return
 	}
 
 	// set timeout based on the round number
-	cfg := c.config.GetConfig(c.current.Sequence())
+	cfg := c.config.GetConfig(seq)
 	baseTimeout := time.Duration(cfg.RequestTimeout) * time.Millisecond
-	round := c.current.Round().Uint64()
+	roundNum := round.Uint64()
 	maxRequestTimeout := time.Duration(cfg.MaxRequestTimeoutSeconds) * time.Second
+	logger := c.logger.New("current.round", roundNum, "current.sequence", seq.Uint64())
 
 	// If the upper limit of the request timeout is capped by small maxRequestTimeout, round can be a quite large number,
 	// which leads to float64 overflow, making its value negative or zero forever after some point.
@@ -356,7 +371,7 @@ func (c *Core) newRoundChangeTimer() {
 	var timeout time.Duration
 	if maxRequestTimeout > time.Duration(0) {
 		timeout = baseTimeout
-		for i := uint64(0); i < round; i++ {
+		for i := uint64(0); i < roundNum; i++ {
 			timeout = timeout * 2
 			if timeout > maxRequestTimeout {
 				timeout = maxRequestTimeout
@@ -365,18 +380,17 @@ func (c *Core) newRoundChangeTimer() {
 		}
 		// prevent log storm when unexpected overflow happens
 		if timeout < baseTimeout {
-			c.currentLogger(true, nil).Warn("WBFT: Possible request timeout overflow detected, setting timeout value to maxRequestTimeout",
+			logger.Warn("WBFT: Possible request timeout overflow detected, setting timeout value to maxRequestTimeout",
 				"timeout", timeout.Seconds(),
 				"max_request_timeout", maxRequestTimeout.Seconds(),
 			)
 			timeout = maxRequestTimeout
 		}
 	} else {
-		timeoutFloat64 := math.Pow(2, float64(round)) * float64(baseTimeout)
+		timeoutFloat64 := math.Pow(2, float64(roundNum)) * float64(baseTimeout)
 
 		if math.IsNaN(timeoutFloat64) || math.IsInf(timeoutFloat64, 0) || timeoutFloat64 > float64(math.MaxInt64) {
-			c.currentLogger(true, nil).Warn("WBFT: Timeout overflow detected, setting timeout value to MaxInt64",
-				"round", round,
+			logger.Warn("WBFT: Timeout overflow detected, setting timeout value to MaxInt64",
 				"adjusted_timeout", time.Duration(math.MaxInt64).Seconds(),
 			)
 			timeout = time.Duration(math.MaxInt64)
@@ -385,7 +399,7 @@ func (c *Core) newRoundChangeTimer() {
 		}
 	}
 
-	c.currentLogger(true, nil).Trace("WBFT: start new ROUND-CHANGE timer", "timeout", timeout.Seconds())
+	logger.Trace("WBFT: start new ROUND-CHANGE timer", "timeout", timeout.Seconds())
 	c.timerMu.Lock()
 	// Capture the canceled pointer in a local variable so the callback
 	// always references this timer's own flag, not a newer one created by

--- a/consensus/wbft/core/core.go
+++ b/consensus/wbft/core/core.go
@@ -387,10 +387,13 @@ func (c *Core) newRoundChangeTimer() {
 
 	c.currentLogger(true, nil).Trace("WBFT: start new ROUND-CHANGE timer", "timeout", timeout.Seconds())
 	c.timerMu.Lock()
-	c.lastSentTimeoutCanceled = new(bool)
-	*c.lastSentTimeoutCanceled = false
+	// Capture the canceled pointer in a local variable so the callback
+	// always references this timer's own flag, not a newer one created by
+	// a subsequent newRoundChangeTimer call.
+	canceled := new(bool)
+	c.lastSentTimeoutCanceled = canceled
 	c.roundChangeTimer = time.AfterFunc(timeout, func() {
-		c.sendEvent(timeoutEvent{c.lastSentTimeoutCanceled})
+		c.sendEvent(timeoutEvent{canceled})
 	})
 	c.timerMu.Unlock()
 }

--- a/consensus/wbft/core/preprepare.go
+++ b/consensus/wbft/core/preprepare.go
@@ -21,6 +21,7 @@
 package core
 
 import (
+	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -165,8 +166,17 @@ func (c *Core) handlePreprepareMsg(preprepare *wbfmessage.Preprepare) error {
 	if c.state == StateAcceptRequest {
 		c.logger.Debug("WBFT: accepted PRE-PREPARE message")
 
-		// Re-initialize ROUND-CHANGE timer
-		c.newRoundChangeTimer()
+		// Re-initialize ROUND-CHANGE timer.
+		// Snapshot the current view under RLock; newRoundChangeTimer no longer
+		// reads c.current and relies solely on the passed-in values.
+		var seq, round *big.Int
+		c.currentMutex.RLock()
+		if c.current != nil {
+			seq = new(big.Int).Set(c.current.Sequence())
+			round = new(big.Int).Set(c.current.Round())
+		}
+		c.currentMutex.RUnlock()
+		c.newRoundChangeTimer(seq, round)
 		c.consensusTimestamp = time.Now()
 
 		// Update current state


### PR DESCRIPTION
## Overview

Fix two race conditions in `newRoundChangeTimer` that could cause unintended round changes during WBFT consensus.

## Problem

1. **Stale canceled pointer in timer callback**: The `time.AfterFunc` callback closure captured `c.lastSentTimeoutCanceled` by reading the struct field at execution time, not at creation time. If `stopTimer` cancelled the old pointer and `newRoundChangeTimer` replaced it with a new one before the goroutine resumed, the callback would read the new (uncanceled) pointer and trigger an unintended round change.

2. **Unsynchronized `c.current` access**: `newRoundChangeTimer` read `c.current.Sequence()` and `c.current.Round()` without holding `currentMutex`, racing with `startNewRound` which updates `c.current` under the same mutex. The existing spin-wait (`for c.current == nil { sleep }`) was a fragile workaround that did not protect against concurrent field updates.

## Solution

1. Capture the `canceled` pointer in a local variable at timer creation time so the callback always references its own flag.

2. Change `newRoundChangeTimer` signature to accept pre-snapshotted `seq` and `round` values. Callers (`startNewRound`, `handlePreprepareMsg`) now snapshot `c.current` under `currentMutex` before calling, eliminating the spin-wait and the unsynchronized reads.

## Changes

- **consensus/wbft/core/core.go**
  - Capture `canceled` pointer in local variable instead of reading `c.lastSentTimeoutCanceled` in callback closure
  - Change `newRoundChangeTimer()` to `newRoundChangeTimer(seq, round *big.Int)` — remove spin-wait and `c.current` reads
  - Replace `c.currentLogger()` calls with snapshot-based logger to avoid mutex contention
  - Update `startNewRound()` call site to pass snapshotted `Sequence`/`Round` under held `Lock()`

- **consensus/wbft/core/preprepare.go**
  - Update `handlePreprepareMsg()` to snapshot `c.current` under `RLock()` before calling `newRoundChangeTimer`