### PR TITLE
fix: reject stale-view justifications in isJustified

### DIFF
--- a/consensus/wbft/core/errors.go
+++ b/consensus/wbft/core/errors.go
@@ -50,3 +50,22 @@ var (
 	// significantly ahead of the current view (in sequence or round).
 	errFutureViewTooFar = errors.New("future view too far ahead: sequence or round difference too large")
 )
+
+// justificationError is returned by isJustified when a validation check fails.
+// Error() returns a fixed string for monitoring grouping; Ctx() returns raw
+// diagnostic key-value pairs; CtxWithErr() prepends "err" to Ctx() for direct
+// use in structured logger calls.
+type justificationError struct {
+	msg string
+	ctx []interface{}
+}
+
+func newJustificationError(msg string, ctx ...interface{}) *justificationError {
+	return &justificationError{msg: msg, ctx: ctx}
+}
+
+func (e *justificationError) Error() string      { return e.msg }
+func (e *justificationError) Ctx() []interface{} { return e.ctx }
+func (e *justificationError) CtxWithErr() []interface{} {
+	return append([]interface{}{"err", e}, e.ctx...)
+}

--- a/consensus/wbft/core/justification.go
+++ b/consensus/wbft/core/justification.go
@@ -30,8 +30,10 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-// Returns true if the `proposal` is justified by the set `roundChangeMessages` of ROUND-CHANGE messages
-// and by the set `prepareMessages` of PREPARE messages.
+// isJustified returns nil if the `proposal` is justified by the set `roundChangeMessages` of
+// ROUND-CHANGE messages and by the set `prepareMessages` of PREPARE messages for `targetView`.
+// All ROUND-CHANGE messages must belong to `targetView` to prevent replay attacks using stale
+// justifications from earlier rounds or sequences.
 // For this we must either have:
 //   - a quorum of ROUND-CHANGE messages with preparedRound and preparedBlockDigest equal to nil; or
 //   - a ROUND-CHANGE message (1) whose preparedRound is not nil and is equal or higher than the
@@ -56,7 +58,8 @@ func isJustified(
 	// This prevents replay attacks using stale justifications from earlier rounds or sequences.
 	for _, rc := range dedupedRoundChanges {
 		if rc.Sequence.Cmp(targetView.Sequence) != 0 || rc.Round.Cmp(targetView.Round) != 0 {
-			return errors.New("round-change message view does not match target view")
+			return newJustificationError("round-change message view does not match target view",
+				"rc.seq", rc.Sequence, "rc.round", rc.Round)
 		}
 	}
 
@@ -70,8 +73,13 @@ func isJustified(
 	if len(dedupedPrepares) > 0 {
 		preparedRound = dedupedPrepares[0].Round
 		for _, spp := range dedupedPrepares {
-			if preparedRound.Cmp(spp.Round) != 0 || proposal.Hash() != spp.Digest {
-				return errors.New("prepared messages do not have same round or do not match proposal")
+			if preparedRound.Cmp(spp.Round) != 0 {
+				return newJustificationError("prepare message round mismatch",
+					"expected", preparedRound, "got", spp.Round)
+			}
+			if proposal.Hash() != spp.Digest {
+				return newJustificationError("prepare message digest mismatch",
+					"proposalHash", proposal.Hash().Hex(), "digest", spp.Digest.Hex())
 			}
 		}
 	}

--- a/consensus/wbft/core/justification.go
+++ b/consensus/wbft/core/justification.go
@@ -39,6 +39,7 @@ import (
 //     preparedBlockDigest match the round and block of `quorumSize` PREPARE messages.
 func isJustified(
 	proposal wbft.Proposal,
+	targetView wbft.View,
 	roundChangeMessages []*wbfmessage.SignedRoundChangePayload,
 	prepareMessages []*wbfmessage.Prepare,
 	quorumSize int) error {
@@ -49,6 +50,14 @@ func isJustified(
 	// Check the size of the set of ROUND-CHANGE messages
 	if len(dedupedRoundChanges) < quorumSize {
 		return errors.New("number of roundchange messages is less than required quorum of messages")
+	}
+
+	// Reject ROUND-CHANGE messages that don't belong to the target view.
+	// This prevents replay attacks using stale justifications from earlier rounds or sequences.
+	for _, rc := range dedupedRoundChanges {
+		if rc.Sequence.Cmp(targetView.Sequence) != 0 || rc.Round.Cmp(targetView.Round) != 0 {
+			return errors.New("round-change message view does not match target view")
+		}
 	}
 
 	// Check the size of the set of PREPARE messages

--- a/consensus/wbft/core/justification_test.go
+++ b/consensus/wbft/core/justification_test.go
@@ -160,14 +160,14 @@ func testParameterizedCase(
 		fmt.Printf("PR %v\n", m)
 	}
 	fmt.Println("roundChangeMessages", roundChangeMessages, len(roundChangeMessages))
-	if err := isJustified(block, roundChangeMessages, prepareMessages, quorumSize); err == nil && !messageJustified {
+	if err := isJustified(block, wbft.View{Sequence: big.NewInt(1), Round: big.NewInt(round)}, roundChangeMessages, prepareMessages, quorumSize); err == nil && !messageJustified {
 		t.Errorf("quorumSize = %v, rcForNil = %v, rcEqualToTargetRound = %v, rcLowerThanTargetRound = %v, rcHigherThanTargetRound = %v, preparesForTargetRound = %v, preparesNotForTargetRound = %v (Expected: %v, Actual: %v)",
 			quorumSize, rcForNil, rcEqualToTargetRound, rcLowerThanTargetRound, rcHigherThanTargetRound, preparesForTargetRound, preparesNotForTargetRound, err == nil, !messageJustified)
 	}
 }
 
 func createRoundChangeMessage(from common.Address, round int64, preparedRound int64, preparedBlock wbft.Proposal) *wbfmessage.SignedRoundChangePayload {
-	m := wbfmessage.NewRoundChange(big.NewInt(1), big.NewInt(1), big.NewInt(preparedRound), preparedBlock)
+	m := wbfmessage.NewRoundChange(big.NewInt(1), big.NewInt(round), big.NewInt(preparedRound), preparedBlock)
 	m.SetSource(from)
 	return &m.SignedRoundChangePayload
 }

--- a/consensus/wbft/core/justification_test.go
+++ b/consensus/wbft/core/justification_test.go
@@ -197,3 +197,114 @@ func makeBlock(number int64) *types.Block {
 	block := &types.Block{}
 	return block.WithSeal(header)
 }
+
+// Tests that isJustified rejects stale-view replay attacks
+// and accepts valid justifications with the correct view.
+func TestJustifyStaleViewReplay(t *testing.T) {
+	quorumSize := 4
+	pp := wbft.NewRoundRobinProposerPolicy()
+	pp.Use(wbft.ValidatorSortByByte())
+	validatorSet := validator.NewSetByValidators(generateValidators(quorumSize), pp)
+	block := makeBlock(1)
+
+	// target view fixed at Sequence 1, Round 2 for all cases
+	targetView := wbft.View{
+		Sequence: big.NewInt(1),
+		Round:    big.NewInt(2),
+	}
+
+	tests := []struct {
+		name            string
+		rcSequence      int64         // Sequence field of the ROUND-CHANGE messages
+		rcRound         int64         // Round field of the ROUND-CHANGE messages
+		rcPreparedRound *big.Int      // PreparedRound of the ROUND-CHANGE messages (nil = not prepared)
+		rcPreparedBlock wbft.Proposal // PreparedBlock carried in the ROUND-CHANGE messages
+		proposedBlock   wbft.Proposal // block the proposer submits in the PRE-PREPARE
+		expectJustify   bool          // expected outcome of isJustified
+	}{
+		// valid: correct-view justifications that must be accepted.
+		{
+			name:            "valid/nil_rc_quorum",
+			rcSequence:      1,
+			rcRound:         2,
+			rcPreparedRound: nil,
+			rcPreparedBlock: nil,
+			proposedBlock:   block,
+			expectJustify:   true,
+		},
+		{
+			name:            "valid/prepared_rc_quorum",
+			rcSequence:      1,
+			rcRound:         2,
+			rcPreparedRound: big.NewInt(1),
+			rcPreparedBlock: block,
+			proposedBlock:   block,
+			expectJustify:   true,
+		},
+		// invalid: malformed justifications with no adversarial gain — the proposer
+		// still proposes the correct prepared block but with wrong-view RCs.
+		{
+			name:            "invalid/stale_round_prepared_rc",
+			rcSequence:      1,
+			rcRound:         1, // replayed from an earlier round
+			rcPreparedRound: big.NewInt(1),
+			rcPreparedBlock: block,
+			proposedBlock:   block,
+			expectJustify:   false,
+		},
+		// attack: proposer replays stale nil RCs to hide an existing
+		// prepared lock and substitute an arbitrary block.
+		{
+			name:            "attack/suppress_prepared_lock",
+			rcSequence:      1,
+			rcRound:         1, // replayed from an earlier round
+			rcPreparedRound: nil,
+			rcPreparedBlock: nil,
+			proposedBlock:   makeBlock(2), // proposes a different block instead of the locked one
+			expectJustify:   false,
+		},
+		{
+			name:            "attack/stale_sequence_rc",
+			rcSequence:      0, // replayed from a previous sequence
+			rcRound:         2,
+			rcPreparedRound: nil,
+			rcPreparedBlock: nil,
+			proposedBlock:   makeBlock(2), // proposes a different block instead of the locked one
+			expectJustify:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// build ROUND-CHANGE messages
+			rcs := make([]*wbfmessage.SignedRoundChangePayload, 0, quorumSize)
+			for _, v := range validatorSet.List() {
+				m := wbfmessage.NewRoundChange(big.NewInt(tc.rcSequence), big.NewInt(tc.rcRound), tc.rcPreparedRound, tc.rcPreparedBlock)
+				m.SetSource(v.Address())
+				rcs = append(rcs, &m.SignedRoundChangePayload)
+			}
+
+			// build PREPARE messages when rcPreparedRound is set
+			var prepares []*wbfmessage.Prepare
+			if tc.rcPreparedRound != nil {
+				prepares = make([]*wbfmessage.Prepare, 0, quorumSize)
+				for _, v := range validatorSet.List() {
+					prepares = append(prepares, createPrepareMessage(v.Address(), tc.rcPreparedRound.Int64(), tc.rcPreparedBlock))
+				}
+			}
+
+			err := isJustified(tc.proposedBlock, targetView, rcs, prepares, quorumSize)
+			if tc.expectJustify {
+				if err != nil {
+					t.Errorf("expected justification to succeed, but it failed: %v (targetView: Seq=%v Rd=%v, rcView: Seq=%v Rd=%v)",
+						err, targetView.Sequence, targetView.Round, tc.rcSequence, tc.rcRound)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("expected justification to fail, but it succeeded (targetView: Seq=%v Rd=%v, rcView: Seq=%v Rd=%v)",
+						targetView.Sequence, targetView.Round, tc.rcSequence, tc.rcRound)
+				}
+			}
+		})
+	}
+}

--- a/consensus/wbft/core/preprepare.go
+++ b/consensus/wbft/core/preprepare.go
@@ -132,7 +132,7 @@ func (c *Core) handlePreprepareMsg(preprepare *wbfmessage.Preprepare) error {
 
 	// Validates PRE-PREPARE message justification
 	if preprepare.Round.Uint64() > 0 {
-		if err := isJustified(preprepare.Proposal, preprepare.JustificationRoundChanges, preprepare.JustificationPrepares, c.valSet.QuorumSize()); err != nil {
+		if err := isJustified(preprepare.Proposal, preprepare.View(), preprepare.JustificationRoundChanges, preprepare.JustificationPrepares, c.valSet.QuorumSize()); err != nil {
 			logger.Warn("WBFT: invalid PRE-PREPARE message justification", "err", err)
 			return errInvalidPreparedBlock
 		}

--- a/consensus/wbft/core/preprepare.go
+++ b/consensus/wbft/core/preprepare.go
@@ -21,6 +21,7 @@
 package core
 
 import (
+	"errors"
 	"math/big"
 	"time"
 
@@ -133,7 +134,12 @@ func (c *Core) handlePreprepareMsg(preprepare *wbfmessage.Preprepare) error {
 	// Validates PRE-PREPARE message justification
 	if preprepare.Round.Uint64() > 0 {
 		if err := isJustified(preprepare.Proposal, preprepare.View(), preprepare.JustificationRoundChanges, preprepare.JustificationPrepares, c.valSet.QuorumSize()); err != nil {
-			logger.Warn("WBFT: invalid PRE-PREPARE message justification", "err", err)
+			var je *justificationError
+			if errors.As(err, &je) {
+				logger.Warn("WBFT: invalid PRE-PREPARE message justification", je.CtxWithErr()...)
+			} else {
+				logger.Warn("WBFT: invalid PRE-PREPARE message justification", "err", err)
+			}
 			return errInvalidPreparedBlock
 		}
 	}

--- a/consensus/wbft/core/roundchange.go
+++ b/consensus/wbft/core/roundchange.go
@@ -194,7 +194,7 @@ func (c *Core) handleRoundChangeMsg(roundChange *wbfmessage.RoundChange) error {
 		}
 
 		prepareMessages := c.roundChangeSet.prepareMessages[currentRound.Uint64()]
-		if err := isJustified(proposal, rcSignedPayloads, prepareMessages, c.valSet.QuorumSize()); err != nil {
+		if err := isJustified(proposal, *c.currentView(), rcSignedPayloads, prepareMessages, c.valSet.QuorumSize()); err != nil {
 			logger.Error("WBFT: invalid ROUND-CHANGE message justification", "err", err)
 			return nil
 		}

--- a/consensus/wbft/core/roundchange.go
+++ b/consensus/wbft/core/roundchange.go
@@ -195,7 +195,12 @@ func (c *Core) handleRoundChangeMsg(roundChange *wbfmessage.RoundChange) error {
 
 		prepareMessages := c.roundChangeSet.prepareMessages[currentRound.Uint64()]
 		if err := isJustified(proposal, *c.currentView(), rcSignedPayloads, prepareMessages, c.valSet.QuorumSize()); err != nil {
-			logger.Error("WBFT: invalid ROUND-CHANGE message justification", "err", err)
+			var je *justificationError
+			if errors.As(err, &je) {
+				logger.Error("WBFT: invalid ROUND-CHANGE message justification", je.CtxWithErr()...)
+			} else {
+				logger.Error("WBFT: invalid ROUND-CHANGE message justification", "err", err)
+			}
 			return nil
 		}
 
@@ -265,10 +270,13 @@ func (rcs *roundChangeSet) Add(r *big.Int, msg wbfmessage.WBFTMessage, preparedR
 
 	if preparedRound != nil && (rcs.highestPreparedRound[round] == nil || preparedRound.Cmp(rcs.highestPreparedRound[round]) > 0) {
 		roundChange := msg.(*wbfmessage.RoundChange)
-		if hasMatchingRoundChangeAndPrepares(roundChange, prepareMessages, quorumSize) == nil {
+		if err := hasMatchingRoundChangeAndPrepares(roundChange, prepareMessages, quorumSize); err == nil {
 			rcs.highestPreparedRound[round] = preparedRound
 			rcs.highestPreparedBlock[round] = preparedBlock
 			rcs.prepareMessages[round] = prepareMessages
+		} else {
+			log.Warn("WBFT: ROUND-CHANGE prepared justification mismatch, ignoring prepared state",
+				"source", roundChange.Source(), "round", round, "err", err)
 		}
 	}
 


### PR DESCRIPTION
## Overview
This PR closes a verification gap in `isJustified` that allowed a Byzantine proposer to replay stale ROUND-CHANGE justifications from an earlier round or sequence to bypass the prepared-lock rule.

## Problem
`isJustified` verified signature validity and quorum size of piggybacked ROUND-CHANGE messages, but did not check whether those messages belong to the same view (Sequence + Round) as the PRE-PREPARE being justified.

A Byzantine proposer could collect a nil ROUND-CHANGE quorum from a past round or the previous sequence, then embed it as justification in a higher-round PRE-PREPARE to claim "no block was prepared" and propose an arbitrary block — bypassing the safety property that requires re-proposing a locked value.

This is exploitable as early as Round 1 using ROUND-CHANGE messages from the previous sequence, provided the validator set overlaps.

## Solution
Add a `targetView wbft.View` parameter to `isJustified` and reject any ROUND-CHANGE message whose Sequence or Round does not match the target view. The PREPARE digest check already implicitly covers the sequence for PREPARE messages (block hash includes block number), so no additional check is needed there.

Additionally, refactors validation checks to return a custom `justificationError` with structured diagnostic contexts, allowing callers to log detailed expected vs actual mismatch values.

## Changes
- `consensus/wbft/core/justification.go`: Add `targetView wbft.View` parameter to `isJustified`; reject ROUND-CHANGE messages that do not match the target view
- `consensus/wbft/core/preprepare.go`: Pass `preprepare.View()` to `isJustified`
- `consensus/wbft/core/roundchange.go`: Pass `*c.currentView()` to `isJustified`
- `consensus/wbft/core/errors.go`: Add `justificationError` struct with structured logging helpers