### PR TITLE
fix(txpool): restore cumulative overdraft check for fee delegation txs

### DIFF
--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -1052,7 +1052,7 @@ func TestAdd(t *testing.T) {
 				{ // New account, 2 pooled tx with 42200 wei spent: reject nonce 2 with 21100 wei spend (1 wei overflow)
 					from: "alice",
 					tx:   makeUnsignedTx(2, 1, 1, 1),
-					err:  nil, // core.ErrInsufficientFunds; WEMIX does not return error; please refer validation.go:251
+					err:  core.ErrInsufficientFunds,
 				},
 			},
 		},
@@ -1181,7 +1181,7 @@ func TestAdd(t *testing.T) {
 				{ // New account, 2 pooled tx with 325344 wei spent: reject nonce 0 with 599684 wei spend (173072 extra) (would overflow balance at nonce 1)
 					from: "alice",
 					tx:   makeUnsignedTx(0, 2, 5, 2),
-					err:  nil, //core.ErrInsufficientFunds,; WEMIX does not return error
+					err:  core.ErrInsufficientFunds,
 				},
 				{ // New account, 2 pooled tx with 325344 wei spent: reject nonce 0 with no-gastip-bump
 					from: "alice",
@@ -1201,7 +1201,7 @@ func TestAdd(t *testing.T) {
 				{ // New account, 2 pooled tx with 325344 wei spent: accept nonce 0 with 84100 wei spend (42000 extra)
 					from: "alice",
 					tx:   makeUnsignedTx(0, 2, 4, 2),
-					err:  txpool.ErrReplaceUnderpriced,
+					err:  nil,
 				},
 			},
 		},

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -246,12 +246,13 @@ type LegacyPool struct {
 	locals  *accountSet // Set of local transaction to exempt from eviction rules
 	journal *journal    // Journal of local transaction to back up to disk
 
-	reserver txpool.Reserver              // Address reserver to ensure exclusivity across subpools
-	pending  map[common.Address]*list     // All currently processable transactions
-	queue    map[common.Address]*list     // Queued but non-processable transactions
-	beats    map[common.Address]time.Time // Last heartbeat from each known account
-	all      *lookup                      // All transactions to allow lookups
-	priced   *pricedList                  // All transactions sorted by price
+	reserver   txpool.Reserver                 // Address reserver to ensure exclusivity across subpools
+	pending    map[common.Address]*list        // All currently processable transactions
+	queue      map[common.Address]*list        // Queued but non-processable transactions
+	pendingGas map[common.Address]*uint256.Int // Cumulative pending gas fee indexed by gas payer (sender, or fee payer for delegation txs)
+	beats      map[common.Address]time.Time    // Last heartbeat from each known account
+	all        *lookup                         // All transactions to allow lookups
+	priced     *pricedList                     // All transactions sorted by price
 
 	reqResetCh      chan *txpoolResetRequest
 	reqPromoteCh    chan *accountSet
@@ -285,6 +286,7 @@ func New(config Config, chain BlockChain) *LegacyPool {
 		signer:          types.LatestSigner(chain.Config()),
 		pending:         make(map[common.Address]*list),
 		queue:           make(map[common.Address]*list),
+		pendingGas:      make(map[common.Address]*uint256.Int),
 		beats:           make(map[common.Address]time.Time),
 		all:             newLookup(),
 		reqResetCh:      make(chan *txpoolResetRequest),
@@ -679,16 +681,32 @@ func (pool *LegacyPool) validateTx(tx *types.Transaction, local bool) error {
 		FirstNonceGap:    nil, // Pool allows arbitrary arrival order, don't invalidate nonce gaps
 		UsedAndLeftSlots: nil, // Pool has own mechanism to limit the number of transactions
 		ExistingExpenditure: func(addr common.Address) *big.Int {
+			// Total wei the account is on the hook for in the pending set (matching
+			// upstream's pending-only accounting): value it owes as a sender, gas it
+			// owes as its own gas payer, and gas it owes as a fee payer for others.
+			// Queued (non-executable) txs are not counted; they are re-checked on
+			// promotion.
+			obligation := new(big.Int)
 			if list := pool.pending[addr]; list != nil {
-				return list.totalcost.ToBig()
+				obligation.Add(obligation, list.totalvalue.ToBig())
+				obligation.Add(obligation, list.totalgas.ToBig())
 			}
-			return new(big.Int)
+			if g := pool.pendingGas[addr]; g != nil {
+				obligation.Add(obligation, g.ToBig())
+			}
+			return obligation
 		},
 		ExistingCost: func(addr common.Address, nonce uint64) *big.Int {
 			if list := pool.pending[addr]; list != nil {
 				if tx := list.txs.Get(nonce); tx != nil {
 					return tx.Cost()
 				}
+			}
+			return nil
+		},
+		ExistingTx: func(addr common.Address, nonce uint64) *types.Transaction {
+			if list := pool.pending[addr]; list != nil {
+				return list.txs.Get(nonce)
 			}
 			return nil
 		},
@@ -1003,7 +1021,12 @@ func (pool *LegacyPool) journalTx(from common.Address, tx *types.Transaction) {
 func (pool *LegacyPool) promoteTx(addr common.Address, hash common.Hash, tx *types.Transaction) bool {
 	// Try to insert the transaction into the pending queue
 	if pool.pending[addr] == nil {
-		pool.pending[addr] = newList(true)
+		list := newList(true)
+		// Share the pool-wide fee-payer gas index by reference so this sender's
+		// fee-delegated txs contribute to their fee payer's cumulative obligation.
+		// Only pending lists are wired up (the overdraft check is pending-only).
+		list.pendingGas = pool.pendingGas
+		pool.pending[addr] = list
 	}
 	list := pool.pending[addr]
 

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -3209,3 +3209,98 @@ func BenchmarkMultiAccountBatchInsert(b *testing.B) {
 		pool.addRemotesSync([]*types.Transaction{tx})
 	}
 }
+
+// feeDelegateTx builds a fee delegation dynamic-fee transaction signed by both
+// the sender (over the inner DynamicFeeTx) and the fee payer (over the wrapping
+// FeeDelegateDynamicFeeTx).
+func feeDelegateTx(chainID *big.Int, nonce uint64, gas uint64, gasFeeCap, gasTipCap, value *big.Int, senderKey, feePayerKey *ecdsa.PrivateKey) *types.Transaction {
+	to := common.Address{}
+	inner := types.DynamicFeeTx{
+		ChainID:   chainID,
+		Nonce:     nonce,
+		GasTipCap: gasTipCap,
+		GasFeeCap: gasFeeCap,
+		Gas:       gas,
+		To:        &to,
+		Value:     value,
+	}
+	signedSender := types.MustSignNewTx(senderKey, types.LatestSignerForChainID(chainID), &inner)
+	v, r, s := signedSender.RawSignatureValues()
+	inner.V, inner.R, inner.S = v, r, s
+
+	feePayer := crypto.PubkeyToAddress(feePayerKey.PublicKey)
+	fd := &types.FeeDelegateDynamicFeeTx{FeePayer: &feePayer}
+	fd.SetSenderTx(inner)
+	return types.MustSignNewTx(feePayerKey, types.NewFeeDelegateSigner(chainID), fd)
+}
+
+// TestFeeDelegationCumulativeGas verifies that the pool aggregates the gas
+// obligations of fee delegation transactions per fee payer across the many
+// sender lists it subsidises, and rejects new transactions once that aggregate
+// would overdraw the fee payer's balance, while leaving the per-sender value
+// accounting intact.
+func TestFeeDelegationCumulativeGas(t *testing.T) {
+	t.Parallel()
+
+	config := *params.TestChainConfig
+	config.ApplepieBlock = big.NewInt(0) // enable fee delegation tx type
+	pool, _ := setupPoolWithConfig(&config)
+	defer pool.Close()
+
+	chainID := config.ChainID
+	const gas = 21000
+	gasFeeCap := big.NewInt(1_000_000_000)
+	gasTipCap := big.NewInt(1)
+	value := big.NewInt(100)
+	perTxGas := new(big.Int).Mul(big.NewInt(gas), gasFeeCap) // FeeCost per tx
+
+	// Fee payer can cover exactly two transactions' gas, not three.
+	feePayerKey, _ := crypto.GenerateKey()
+	feePayer := crypto.PubkeyToAddress(feePayerKey.PublicKey)
+	testAddBalance(pool, feePayer, new(big.Int).Add(new(big.Int).Mul(perTxGas, big.NewInt(2)), new(big.Int).Div(perTxGas, big.NewInt(2))))
+
+	// Three distinct senders, each amply funded for their own value transfer.
+	senders := make([]*ecdsa.PrivateKey, 3)
+	txs := make([]*types.Transaction, 3)
+	for i := range senders {
+		senders[i], _ = crypto.GenerateKey()
+		testAddBalance(pool, crypto.PubkeyToAddress(senders[i].PublicKey), big.NewInt(1_000_000))
+		txs[i] = feeDelegateTx(chainID, 0, gas, gasFeeCap, gasTipCap, value, senders[i], feePayerKey)
+	}
+
+	// First two transactions fit within the fee payer's balance.
+	if err := pool.Add([]*types.Transaction{txs[0]}, true, true)[0]; err != nil {
+		t.Fatalf("tx 0: unexpected error: %v", err)
+	}
+	if err := pool.Add([]*types.Transaction{txs[1]}, true, true)[0]; err != nil {
+		t.Fatalf("tx 1: unexpected error: %v", err)
+	}
+
+	// The pool-wide gas index must now reflect both transactions' fees.
+	pool.mu.RLock()
+	gotGas := new(big.Int)
+	if g := pool.pendingGas[feePayer]; g != nil {
+		gotGas = g.ToBig()
+	}
+	pool.mu.RUnlock()
+	if want := new(big.Int).Mul(perTxGas, big.NewInt(2)); gotGas.Cmp(want) != 0 {
+		t.Fatalf("pendingGas[feePayer] = %v, want %v", gotGas, want)
+	}
+
+	// The third transaction is individually affordable, but pushes the fee
+	// payer's aggregate gas obligation over its balance and must be rejected.
+	if err := pool.Add([]*types.Transaction{txs[2]}, true, true)[0]; !errors.Is(err, txpool.ErrFeePayerInsufficientFunds) {
+		t.Fatalf("tx 2: error = %v, want %v", err, txpool.ErrFeePayerInsufficientFunds)
+	}
+
+	// Removing one accepted transaction frees enough of the fee payer's budget
+	// for the previously rejected one to be admitted, proving the index is also
+	// maintained on removal.
+	pool.removeTx(txs[0].Hash(), false, true)
+	if err := pool.Add([]*types.Transaction{txs[2]}, true, true)[0]; err != nil {
+		t.Fatalf("tx 2 after removal: unexpected error: %v", err)
+	}
+	if err := validatePoolInternals(pool); err != nil {
+		t.Fatalf("pool internal state corrupted: %v", err)
+	}
+}

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -277,16 +277,36 @@ type list struct {
 	costcap   *uint256.Int // Price of the highest costing transaction (reset only if exceeds balance)
 	gascap    uint64       // Gas limit of the highest spending transaction (reset only if exceeds block limit)
 	totalcost *uint256.Int // Total cost of all transactions in the list
+
+	// totalvalue is the cumulative tx.Value() of every transaction in the list,
+	// i.e. the amount this account owes purely as a *sender* (regardless of who
+	// pays the gas). Used for the cumulative overdraft check.
+	totalvalue *uint256.Int
+
+	// totalgas is the cumulative gas-side cost (tx.FeeCost()) of the transactions
+	// in this list for which this account is also the gas payer, i.e. every
+	// non-fee-delegated transaction. Gas owed via fee delegation is attributed to
+	// the fee payer through pendingGas instead, since that account may not have a
+	// list of its own.
+	totalgas *uint256.Int
+
+	// pendingGas is a pool-wide map (shared by reference across all per-account
+	// lists) tracking the cumulative gas (tx.FeeCost()) each account owes when it
+	// acts as the fee payer of fee-delegated transactions. nil is tolerated
+	// (e.g. in unit tests), in which case fee-delegation gas is simply not tracked.
+	pendingGas map[common.Address]*uint256.Int
 }
 
 // newList creates a new transaction list for maintaining nonce-indexable fast,
 // gapped, sortable transaction lists.
 func newList(strict bool) *list {
 	return &list{
-		strict:    strict,
-		txs:       newSortedMap(),
-		costcap:   new(uint256.Int),
-		totalcost: new(uint256.Int),
+		strict:     strict,
+		txs:        newSortedMap(),
+		costcap:    new(uint256.Int),
+		totalcost:  new(uint256.Int),
+		totalvalue: new(uint256.Int),
+		totalgas:   new(uint256.Int),
 	}
 }
 
@@ -333,6 +353,7 @@ func (l *list) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Transa
 		return false, nil
 	}
 	l.totalcost.Add(l.totalcost, cost)
+	l.addCost(tx)
 
 	// Otherwise overwrite the old transaction with the current one
 	l.txs.Put(tx)
@@ -471,6 +492,60 @@ func (l *list) subTotalCost(txs []*types.Transaction) {
 		if underflow {
 			panic("totalcost underflow")
 		}
+		l.subCost(tx)
+	}
+}
+
+// addCost attributes a transaction's value and gas obligations to the right
+// accounts: the value is always owed by the sender (this list's owner), while
+// the gas is owed by the sender for normal transactions or by the fee payer for
+// fee-delegated transactions (tracked pool-wide via pendingGas).
+func (l *list) addCost(tx *types.Transaction) {
+	l.totalvalue.Add(l.totalvalue, uint256.MustFromBig(tx.Value()))
+
+	feeCost := uint256.MustFromBig(tx.FeeCost())
+	if tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() != nil {
+		if l.pendingGas == nil {
+			return
+		}
+		payer := *tx.FeePayer()
+		acc := l.pendingGas[payer]
+		if acc == nil {
+			acc = new(uint256.Int)
+			l.pendingGas[payer] = acc
+		}
+		acc.Add(acc, feeCost)
+		return
+	}
+	l.totalgas.Add(l.totalgas, feeCost)
+}
+
+// subCost reverses addCost for a removed transaction.
+func (l *list) subCost(tx *types.Transaction) {
+	if _, underflow := l.totalvalue.SubOverflow(l.totalvalue, uint256.MustFromBig(tx.Value())); underflow {
+		panic("totalvalue underflow")
+	}
+
+	feeCost := uint256.MustFromBig(tx.FeeCost())
+	if tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() != nil {
+		if l.pendingGas == nil {
+			return
+		}
+		payer := *tx.FeePayer()
+		acc := l.pendingGas[payer]
+		if acc == nil {
+			panic("pendingGas underflow")
+		}
+		if _, underflow := acc.SubOverflow(acc, feeCost); underflow {
+			panic("pendingGas underflow")
+		}
+		if acc.IsZero() {
+			delete(l.pendingGas, payer)
+		}
+		return
+	}
+	if _, underflow := l.totalgas.SubOverflow(l.totalgas, feeCost); underflow {
+		panic("totalgas underflow")
 	}
 }
 

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -220,13 +220,25 @@ type ValidationOptionsWithState struct {
 	// be rejected once the number of remaining slots reaches zero.
 	UsedAndLeftSlots func(addr common.Address) (int, int)
 
-	// ExistingExpenditure is a mandatory callback to retrieve the cumulative
-	// cost of the already pooled transactions to check for overdrafts.
+	// ExistingExpenditure is a mandatory callback to retrieve an account's total
+	// cumulative obligation across every role it plays in the pending set: value
+	// it owes as a sender, gas it owes as its own gas payer, and gas it owes as a
+	// fee payer for others' fee-delegated transactions. This single "total
+	// obligation" view keeps the overdraft check correct for both ordinary and
+	// fee-delegated transactions.
 	ExistingExpenditure func(addr common.Address) *big.Int
 
 	// ExistingCost is a mandatory callback to retrieve an already pooled
 	// transaction's cost with the given nonce to check for overdrafts.
 	ExistingCost func(addr common.Address, nonce uint64) *big.Int
+
+	// ExistingTx is an optional callback to retrieve the already pooled
+	// transaction (if any) with the given sender and nonce, i.e. the transaction
+	// that an incoming one would replace. It lets the cumulative overdraft check
+	// split the replaced transaction's value and gas across the right accounts,
+	// which is required for fee-delegated transactions. When nil, the check falls
+	// back to ExistingCost and assumes the replaced transaction was sender-paid.
+	ExistingTx func(addr common.Address, nonce uint64) *types.Transaction
 
 	// AnzeonTipEnv is an optional environment for computing and caching
 	// the Anzeon gas tip cap during validation to avoid repeated state queries during reheap.
@@ -271,21 +283,15 @@ func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, op
 		cost    = tx.Cost()
 	)
 	if tx.Type() == types.FeeDelegateDynamicFeeTxType {
-		var (
-			txValue         = tx.Value()
-			txFeeCost       = tx.FeeCost()
-			feePayer        = *tx.FeePayer()
-			feePayerBalance = opts.State.GetBalance(feePayer).ToBig()
-		)
 		// Ensure that the fee payer is not blacklisted
-		if opts.Config.AnzeonEnabled() && opts.State.IsBlacklisted(feePayer) {
-			return &core.ErrBlacklistedAccount{Address: feePayer}
+		if opts.Config.AnzeonEnabled() && opts.State.IsBlacklisted(*tx.FeePayer()) {
+			return &core.ErrBlacklistedAccount{Address: *tx.FeePayer()}
 		}
-		if balance.Cmp(txValue) < 0 {
-			return fmt.Errorf("%w: balance %v, tx value %v, overshot %v", ErrSenderInsufficientFunds, balance, txValue, new(big.Int).Sub(txValue, balance))
+		if opts.State.GetBalance(from).ToBig().Cmp(tx.Value()) < 0 {
+			return ErrSenderInsufficientFunds
 		}
-		if feePayerBalance.Cmp(txFeeCost) < 0 {
-			return fmt.Errorf("%w: balance %v, fee cost %v, overshot %v", ErrFeePayerInsufficientFunds, feePayerBalance, txFeeCost, new(big.Int).Sub(txFeeCost, feePayerBalance))
+		if opts.State.GetBalance(*tx.FeePayer()).ToBig().Cmp(tx.FeeCost()) < 0 {
+			return ErrFeePayerInsufficientFunds
 		}
 	} else {
 		if balance.Cmp(cost) < 0 {
@@ -302,35 +308,98 @@ func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, op
 		}
 	}
 
-	// go-stablenet skips cumulative balance validation for fee delegation tx compatibility.
-	// Fee delegation transactions split costs between sender (value only) and feePayer (gas fees),
-	// but ExistingExpenditure callback sums total tx.Cost() which is incompatible with this model.
-	// Enabling this validation would incorrectly reject transactions when fee delegation txs exist
-	// in the pending pool, as it would compare sender's balance against the full cost (value + gas).
-	// Transaction replacement is still supported via legacypool's price bump mechanism.
-	/*
-		// Ensure the transactor has enough funds to cover for replacements or nonce
-		// expansions without overdrafts
-		spent := opts.ExistingExpenditure(from)
-		if prev := opts.ExistingCost(from, tx.Nonce()); prev != nil {
-			bump := new(big.Int).Sub(cost, prev)
-			need := new(big.Int).Add(spent, bump)
-			if balance.Cmp(need) < 0 {
-				return fmt.Errorf("%w: balance %v, queued cost %v, tx bumped %v, overshot %v", core.ErrInsufficientFunds, balance, spent, bump, new(big.Int).Sub(need, balance))
+	// Cumulative overdraft protection (DoS hardening).
+	//
+	// A transaction can clear the per-tx balance checks above yet still be
+	// uncoverable once combined with the account's other pooled obligations. Left
+	// unchecked, an attacker can flood the pool with individually-valid but
+	// collectively-unfundable transactions (sequential value overdrafts from one
+	// sender, or many senders piling gas onto a single fee payer) that mostly
+	// revert on execution and pollute the mempool.
+	//
+	// Fee delegation (tx type 0x16) splits an obligation across two accounts: the
+	// sender owes the value, the fee payer owes the gas (FeeCost). The
+	// ExistingExpenditure callback therefore reports each account's *total*
+	// obligation across every role it plays (value as sender, gas as its own gas
+	// payer, and gas as a fee payer for others), so the checks below remain correct
+	// for both normal and fee-delegated transactions.
+	if opts.ExistingExpenditure != nil {
+		// Determine who is responsible for the gas fee of the incoming transaction.
+		gasPayer := from
+		if tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() != nil {
+			gasPayer = *tx.FeePayer()
+		}
+		txValue := tx.Value()
+		txGasCost := tx.FeeCost() // tx.Cost() - tx.Value()
+
+		// If a transaction with the same sender and nonce is already pooled, the
+		// incoming one replaces it, so its contribution must be discounted from
+		// whichever account currently carries it (value -> sender, gas -> its own
+		// gas payer, which may differ from the new transaction's gas payer).
+		var (
+			hasPrev      bool
+			prevGasPayer = from
+			prevValue    = new(big.Int)
+			prevGasCost  = new(big.Int)
+		)
+		if opts.ExistingTx != nil {
+			if prev := opts.ExistingTx(from, tx.Nonce()); prev != nil {
+				hasPrev = true
+				prevValue = prev.Value()
+				prevGasCost = prev.FeeCost()
+				if prev.Type() == types.FeeDelegateDynamicFeeTxType && prev.FeePayer() != nil {
+					prevGasPayer = *prev.FeePayer()
+				}
+			}
+		} else if prev := opts.ExistingCost(from, tx.Nonce()); prev != nil {
+			// Pools without fee-delegation support (e.g. the blob pool): the replaced
+			// transaction is fully sender-paid, so its whole cost belongs to the sender.
+			hasPrev = true
+			prevGasCost = prev // prev == old.Cost(); oldGasPayer == from
+		}
+
+		// need computes an account's total pooled obligation (value owed as a
+		// sender plus gas owed as a gas payer), augmented by the incoming
+		// transaction's deltas and discounted by any transaction being replaced.
+		need := func(addr common.Address, addValue, addGas *big.Int) *big.Int {
+			n := new(big.Int).Set(opts.ExistingExpenditure(addr))
+			n.Add(n, addValue)
+			n.Add(n, addGas)
+			if hasPrev {
+				if addr == from {
+					n.Sub(n, prevValue)
+				}
+				if addr == prevGasPayer {
+					n.Sub(n, prevGasCost)
+				}
+				if n.Sign() < 0 {
+					n.SetInt64(0) // guard against accounting drift
+				}
+			}
+			return n
+		}
+
+		zero := new(big.Int)
+		if from == gasPayer {
+			// Self-paid: value and gas are drawn from the same balance and must be
+			// checked combined, otherwise an account could overdraft by splitting
+			// its obligations across two independent checks.
+			n := need(from, txValue, txGasCost)
+			if balance.Cmp(n) < 0 {
+				return fmt.Errorf("%w: balance %v, needed %v, overshot %v", core.ErrInsufficientFunds, balance, n, new(big.Int).Sub(n, balance))
 			}
 		} else {
-			need := new(big.Int).Add(spent, cost)
-			if balance.Cmp(need) < 0 {
-				return fmt.Errorf("%w: balance %v, queued cost %v, tx cost %v, overshot %v", core.ErrInsufficientFunds, balance, spent, cost, new(big.Int).Sub(need, balance))
+			// Fee delegation: the sender covers its value obligations, the fee
+			// payer covers its gas obligations, each against its own balance.
+			if nv := need(from, txValue, zero); balance.Cmp(nv) < 0 {
+				return fmt.Errorf("%w: sender balance %v, needed %v, overshot %v", ErrSenderInsufficientFunds, balance, nv, new(big.Int).Sub(nv, balance))
 			}
-			// Transaction takes a new nonce value out of the pool. Ensure it doesn't
-			// overflow the number of permitted transactions from a single account
-			// (i.e. max cancellable via out-of-bound transaction).
-			if used, left := opts.UsedAndLeftSlots(from); left <= 0 {
-				return fmt.Errorf("%w: pooled %d txs", ErrAccountLimitExceeded, used)
+			feePayerBalance := opts.State.GetBalance(gasPayer).ToBig()
+			if ng := need(gasPayer, zero, txGasCost); feePayerBalance.Cmp(ng) < 0 {
+				return fmt.Errorf("%w: fee payer balance %v, needed %v, overshot %v", ErrFeePayerInsufficientFunds, feePayerBalance, ng, new(big.Int).Sub(ng, feePayerBalance))
 			}
 		}
-	*/
+	}
 
 	// Cache the Anzeon tip cap to avoid repeated state queries during reheap
 	// Only cache if not already set (to preserve original value during reinject)


### PR DESCRIPTION
## Summary

Fee delegation tx (type 0x16) splits cost between sender (value) and feePayer (gas fee). The upstream cumulative overdraft check(introduced in ethereum/go-ethereum#27429) assumed a single payer via `totalcost`, causing false positives for valid fee delegation txs. As a workaround the check was globally disabled, leaving the pool exposed to two DoS vectors:

1. A single sender submitting sequential txs whose aggregate value exceeds balance — each passes per-tx validation individually but reverts on execution, polluting the mempool.
2. Multiple senders designating the same feePayer, collectively exceeding the feePayer's balance with no pool-level rejection.

## Changes

- **list.go**: add `totalvalue`, `totalgas`, `pendingGas` (pool-wide shared map); implement `addCost`/`subCost`. `pendingGas` aggregates gas obligations across all sender lists sharing the same feePayer, enabling cross-sender tracking.
- **legacypool.go**: inject `pendingGas` by reference into each pending list (pending-only). `ExistingExpenditure` returns total obligation across three roles: sender (`totalvalue`), own gas payer (`totalgas`), fee payer for others (`pendingGas`). `ExistingTx` added for correct replacement accounting.
- **validation.go**: replace disabled block with unified cumulative check via `need()`. Normal txs: combined balance check. Fee delegation txs: sender/feePayer checked independently.
- **blobpool_test.go**: restore upstream `core.ErrInsufficientFunds` expectations.
- **legacypool_test.go**: add `TestFeeDelegationCumulativeGas`.

## Test

- [x] `go test ./core/txpool/legacypool/ -run TestFeeDelegationCumulativeGas -v`
- [x] `go test ./core/txpool/legacypool/ ./core/txpool/blobpool/`
- [x] `go test -race ./core/txpool/legacypool/`
