### PR TITLE
fix: remove DecodeVanityData and return vanityData as raw hex

### DIFF
--- a/consensus/wbft/backend/api.go
+++ b/consensus/wbft/backend/api.go
@@ -427,23 +427,37 @@ func DecodeVanityData(vanity []byte) string {
 	}
 
 	var val []interface{}
+	if err := rlp.DecodeBytes(clean, &val); err != nil || len(val) < 4 {
+		return unknownVanity(clean)
+	}
 
-	err := rlp.DecodeBytes(clean, &val)
-	versionBytes := val[0].([]uint8)
+	versionBytes, ok := val[0].([]uint8)
+	if !ok {
+		return unknownVanity(clean)
+	}
+
 	if len(versionBytes) < 3 {
 		tempBytes := make([]uint8, 3)
 		copy(tempBytes[3-len(versionBytes):], versionBytes)
 		versionBytes = tempBytes
 	}
-	version := uint32(versionBytes[0])<<16 | uint32(versionBytes[1])<<8 | uint32(versionBytes[2])
-	if err == nil && version > 0 {
-		major, minor, patch := versionBytes[0], versionBytes[1], versionBytes[2]
-		clientBytes := val[1].([]byte)
-		goVerBytes := val[2].([]byte)
-		goOSBytes := val[3].([]byte)
-		return fmt.Sprintf("[version: v%d.%d.%d, client: %s, go: %s, os: %s]", major, minor, patch, string(clientBytes), string(goVerBytes), string(goOSBytes))
+
+	major, minor, patch := versionBytes[0], versionBytes[1], versionBytes[2]
+	if uint32(major)<<16|uint32(minor)<<8|uint32(patch) == 0 {
+		return unknownVanity(clean)
 	}
 
+	clientBytes, ok1 := val[1].([]byte)
+	goVerBytes, ok2 := val[2].([]byte)
+	goOSBytes, ok3 := val[3].([]byte)
+	if !ok1 || !ok2 || !ok3 {
+		return unknownVanity(clean)
+	}
+
+	return fmt.Sprintf("[version: v%d.%d.%d, client: %s, go: %s, os: %s]", major, minor, patch, string(clientBytes), string(goVerBytes), string(goOSBytes))
+}
+
+func unknownVanity(clean []byte) string {
 	return fmt.Sprintf("Unknown vanityData format, hex: 0x%s", hex.EncodeToString(clean))
 }
 

--- a/consensus/wbft/backend/api.go
+++ b/consensus/wbft/backend/api.go
@@ -21,18 +21,15 @@
 package backend
 
 import (
-	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
-	"unicode/utf8"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	wbftcommon "github.com/ethereum/go-ethereum/consensus/wbft/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -417,50 +414,6 @@ func epochForJSON(epoch *types.EpochInfo) map[string]interface{} {
 	}
 }
 
-// DecodeVanityData decodes a 32-byte vanityData field.
-// It detects if the input is UTF-8 or RLP encoded, and decodes accordingly.
-func DecodeVanityData(vanity []byte) string {
-	clean := bytes.TrimRight(vanity, "\x00")
-
-	if utf8.Valid(clean) {
-		return string(clean)
-	}
-
-	var val []interface{}
-	if err := rlp.DecodeBytes(clean, &val); err != nil || len(val) < 4 {
-		return unknownVanity(clean)
-	}
-
-	versionBytes, ok := val[0].([]uint8)
-	if !ok {
-		return unknownVanity(clean)
-	}
-
-	if len(versionBytes) < 3 {
-		tempBytes := make([]uint8, 3)
-		copy(tempBytes[3-len(versionBytes):], versionBytes)
-		versionBytes = tempBytes
-	}
-
-	major, minor, patch := versionBytes[0], versionBytes[1], versionBytes[2]
-	if uint32(major)<<16|uint32(minor)<<8|uint32(patch) == 0 {
-		return unknownVanity(clean)
-	}
-
-	clientBytes, ok1 := val[1].([]byte)
-	goVerBytes, ok2 := val[2].([]byte)
-	goOSBytes, ok3 := val[3].([]byte)
-	if !ok1 || !ok2 || !ok3 {
-		return unknownVanity(clean)
-	}
-
-	return fmt.Sprintf("[version: v%d.%d.%d, client: %s, go: %s, os: %s]", major, minor, patch, string(clientBytes), string(goVerBytes), string(goOSBytes))
-}
-
-func unknownVanity(clean []byte) string {
-	return fmt.Sprintf("Unknown vanityData format, hex: 0x%s", hex.EncodeToString(clean))
-}
-
 func (api *API) GetWbftExtraInfo(number rpc.BlockNumber) (map[string]interface{}, error) {
 	bNumber := big.NewInt(int64(number))
 
@@ -484,7 +437,7 @@ func (api *API) GetWbftExtraInfo(number rpc.BlockNumber) (map[string]interface{}
 	}
 
 	result := map[string]interface{}{
-		"vanityData":        DecodeVanityData(extra.VanityData),
+		"vanityData":        "0x" + hex.EncodeToString(extra.VanityData),
 		"randaoReveal":      "0x" + hex.EncodeToString(extra.RandaoReveal),
 		"prevRound":         fmt.Sprintf("0x%x", extra.PrevRound),
 		"prevPreparedSeal":  sealForJSON(extra.PrevPreparedSeal, prevValidators.AddressList()),


### PR DESCRIPTION
## Overview

Prevent potential runtime panics when decoding invalid block vanity data by enhancing error validation and type assertions.

## Problem

When decoding a block's vanity data, accessing the resulting slice prior to verifying the decoding status causes an index out-of-range panic if the decoding fails. Additionally, performing type assertions on the decoded interfaces without validation causes interface conversion panics on malformed block data, leading to node instability.

## Initial Approach — Superseded by Design Decision below

> ## Solution
>
> Ensure that decoding errors and slice lengths are validated immediately after decoding the bytes. Check the success of all subsequent type assertions before using the values.
>
> ## Changes
>
> - Add error check and slice length validation right after decoding the vanity data
> - Validate type assertion success for all decoded fields to prevent runtime panics

---

## Design Decision: Remove DecodeVanityData

While investigating the panic fixes above, a deeper structural issue was identified that led to a change in approach — removing `DecodeVanityData` entirely rather than applying defensive guards.

**1. No protocol-enforced format**
`VanityData` is an unconstrained 32-byte buffer. The protocol imposes no format requirement; validators can write arbitrary bytes. Defensively guarding against decode failures treats a symptom rather than the root cause.

**2. Implicit cross-package coupling**
`DecodeVanityData` hardcodes the RLP schema `[uint, string, string, string]` produced by `eth` package `makeExtraData()`. Any change to the encoding side in the `eth` package would silently break the decoding side in the `wbft` package with no compile-time signal.

**3. No consensus role**
The consensus engine never reads or validates `VanityData` content during block verification. The field serves purely as a 32-byte buffer for node metadata, with no functional impact on consensus.

**Revised Changes**

- Remove `DecodeVanityData`
- Return `vanityData` as a raw hex string in `GetWbftExtraInfo`, consistent with other byte fields (`randaoReveal`, seal signatures)