### PR TITLE
fix: harden WBFT backlog against future-message flooding

### DIFF
--- a/consensus/wbft/core/backlog.go
+++ b/consensus/wbft/core/backlog.go
@@ -50,6 +50,14 @@ const (
 	maxBacklogSizePerValidator = 4 * (roundThreshold + 1) * (sequenceThreshold + 1)
 )
 
+// backlogKey identifies a message slot within a single validator's backlog
+// by message type, sequence, and round.
+type backlogKey struct {
+	code     uint64
+	sequence uint64
+	round    uint64
+}
+
 // isSequenceTooFarAhead returns true if the sequence difference exceeds the threshold
 func (c *Core) isSequenceTooFarAhead(viewSeq, currSeq *big.Int, threshold int64) (*big.Int, bool) {
 	seqDiff := new(big.Int).Sub(viewSeq, currSeq)
@@ -211,17 +219,27 @@ func (c *Core) addToBacklog(msg wbfmessage.WBFTMessage) {
 	defer c.backlogsMu.Unlock()
 
 	backlog := c.backlogs[src]
+	view := msg.View()
+	pkey := backlogKey{msg.Code(), view.Sequence.Uint64(), view.Round.Uint64()}
+
 	if backlog == nil {
+		// First message from this validator: size and dedup checks are unnecessary.
 		backlog = prque.New[int64, wbfmessage.WBFTMessage](nil)
 		c.backlogs[src] = backlog
+		c.backlogKeys[src] = make(map[backlogKey]struct{})
 	} else {
+		// Drop the message if the same (code, sequence, round) slot is already queued for this validator.
+		if _, exists := c.backlogKeys[src][pkey]; exists {
+			logger.Trace("WBFT: duplicate backlog message, dropping", "src", src)
+			return
+		}
 		// Reject messages from a validator whose backlog exceeds the size limit.
 		if backlog.Size() >= maxBacklogSizePerValidator {
 			logger.Warn("WBFT: backlog is full, dropping message", "src", src, "size", backlog.Size())
 			return
 		}
 	}
-	view := msg.View()
+	c.backlogKeys[src][pkey] = struct{}{}
 	backlog.Push(msg, toNegatePriority(msg.Code(), &view))
 }
 
@@ -241,6 +259,7 @@ func (c *Core) processBacklog() {
 		if src == nil {
 			// validator is not available
 			delete(c.backlogs, srcAddress)
+			delete(c.backlogKeys, srcAddress) // purge all keys for the departing validator
 			continue
 		}
 		logger := c.logger.New("from", src, "state", c.state)
@@ -261,6 +280,7 @@ func (c *Core) processBacklog() {
 			code = msg.Code()
 			view = msg.View()
 			event.msg = msg
+			pkey := backlogKey{msg.Code(), view.Sequence.Uint64(), view.Round.Uint64()}
 
 			// Push back if it's a future message
 			err := c.checkMessage(code, &view)
@@ -272,9 +292,12 @@ func (c *Core) processBacklog() {
 					isFuture = true
 					break
 				}
+				// Message is expired or invalid and will never be processable; remove its key.
+				delete(c.backlogKeys[srcAddress], pkey)
 				logger.Trace("WBFT: skip backlog message", "msg", msg, "err", err)
 				continue
 			}
+			delete(c.backlogKeys[srcAddress], pkey) // remove key on dispatch
 			logger.Trace("WBFT: post backlog event", "msg", msg)
 
 			event.src = src

--- a/consensus/wbft/core/backlog.go
+++ b/consensus/wbft/core/backlog.go
@@ -74,6 +74,16 @@ func (c *Core) isTooFarFutureMessage(view *wbft.View) bool {
 			)
 			return true
 		}
+		// Reject future sequence messages with an excessively high round number.
+		// All rounds in a future sequence are future rounds; rounds 0 to roundThreshold-1 are allowed.
+		if view.Round.Cmp(big.NewInt(roundThreshold)) >= 0 {
+			c.logger.Trace("WBFT: future sequence message too far ahead in round, dropped",
+				"msg_view", view.String(),
+				"curr_view", curr.String(),
+				"threshold", roundThreshold,
+			)
+			return true
+		}
 	}
 
 	if view.Sequence.Cmp(curr.Sequence) == 0 && view.Round.Cmp(curr.Round) > 0 {

--- a/consensus/wbft/core/backlog.go
+++ b/consensus/wbft/core/backlog.go
@@ -44,6 +44,10 @@ var (
 const (
 	sequenceThreshold = 1  // Allow up to 1 future sequence
 	roundThreshold    = 10 // Allow up to 10 future rounds
+
+	// maxBacklogSizePerValidator caps the number of backlog messages per validator,
+	// computed as an upper bound over all 4 message types, rounds, and sequences.
+	maxBacklogSizePerValidator = 4 * (roundThreshold + 1) * (sequenceThreshold + 1)
 )
 
 // isSequenceTooFarAhead returns true if the sequence difference exceeds the threshold
@@ -210,6 +214,12 @@ func (c *Core) addToBacklog(msg wbfmessage.WBFTMessage) {
 	if backlog == nil {
 		backlog = prque.New[int64, wbfmessage.WBFTMessage](nil)
 		c.backlogs[src] = backlog
+	} else {
+		// Reject messages from a validator whose backlog exceeds the size limit.
+		if backlog.Size() >= maxBacklogSizePerValidator {
+			logger.Warn("WBFT: backlog is full, dropping message", "src", src, "size", backlog.Size())
+			return
+		}
 	}
 	view := msg.View()
 	backlog.Push(msg, toNegatePriority(msg.Code(), &view))

--- a/consensus/wbft/core/backlog_test.go
+++ b/consensus/wbft/core/backlog_test.go
@@ -3,6 +3,12 @@ package core
 import (
 	"math/big"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/wbft"
+	wbftmsg "github.com/ethereum/go-ethereum/consensus/wbft/messages"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 func TestIsSequenceTooFarAhead(t *testing.T) {
@@ -47,5 +53,218 @@ func TestIsRoundTooFarAhead(t *testing.T) {
 		if tooFar != tt.expected {
 			t.Errorf("isRoundTooFarAhead(%d, %d, %d) = %v; want %v", tt.viewRound, tt.currRound, threshold, tooFar, tt.expected)
 		}
+	}
+}
+
+// TestIsTooFarFutureMessageRoundThreshold verifies that future-sequence messages
+// with a round exceeding roundThreshold are rejected, while same-sequence messages
+// use a relative round check against the current round.
+func TestIsTooFarFutureMessageRoundThreshold(t *testing.T) {
+	// Current view: seq=100, round=0
+	core := makeCoreForTest(common.Big0, common.Big0, big.NewInt(100), nil)
+
+	tests := []struct {
+		name     string
+		seq      int64
+		round    int64
+		expected bool
+	}{
+		// Future sequence (n+1): absolute round check from 0
+		{"future seq, round below threshold", 101, roundThreshold - 1, false},
+		{"future seq, round at threshold", 101, roundThreshold, true},
+		{"future seq, round exceeds threshold", 101, roundThreshold + 1, true},
+		{"future seq, round way over threshold", 101, 1000000, true},
+		// Same sequence: relative round check from current round (0)
+		{"same seq, round at threshold", 100, roundThreshold, false},
+		{"same seq, round exceeds threshold", 100, roundThreshold + 1, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			view := &wbft.View{
+				Sequence: big.NewInt(tt.seq),
+				Round:    big.NewInt(tt.round),
+			}
+			result := core.isTooFarFutureMessage(view)
+			if result != tt.expected {
+				t.Errorf("isTooFarFutureMessage(seq=%d, round=%d) = %v; want %v",
+					tt.seq, tt.round, result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestAddToBacklogSizeLimit verifies that messages beyond maxBacklogSizePerValidator
+// are dropped for a given source address.
+func TestAddToBacklogSizeLimit(t *testing.T) {
+	proposal := makeProposal(big.NewInt(100))
+	core := makeCoreForTest(common.Big0, common.Big0, big.NewInt(101), proposal)
+
+	src := crypto.PubkeyToAddress(signers[1].PublicKey)
+	seq := big.NewInt(101)
+
+	// Fill the backlog to the limit using distinct rounds to avoid dedup.
+	for i := 0; i < maxBacklogSizePerValidator; i++ {
+		addBacklogMsg(t, core, wbftmsg.PrepareCode, 1, proposal, seq, big.NewInt(int64(i)))
+	}
+
+	if core.backlogs[src].Size() != maxBacklogSizePerValidator {
+		t.Fatalf("expected backlog size %d, got %d", maxBacklogSizePerValidator, core.backlogs[src].Size())
+	}
+
+	// One more message should be dropped.
+	addBacklogMsg(t, core, wbftmsg.PrepareCode, 1, proposal, seq, big.NewInt(maxBacklogSizePerValidator))
+
+	if core.backlogs[src].Size() != maxBacklogSizePerValidator {
+		t.Errorf("expected backlog size to remain %d after overflow, got %d",
+			maxBacklogSizePerValidator, core.backlogs[src].Size())
+	}
+}
+
+// TestAddToBacklogDedup verifies that a second message with the same
+// (code, sequence, round) from the same validator is dropped regardless of payload.
+func TestAddToBacklogDedup(t *testing.T) {
+	proposal := makeProposal(big.NewInt(100))
+	otherProposal := makeProposal(big.NewInt(99)) // distinct proposal to produce a different digest
+	core := makeCoreForTest(common.Big0, common.Big0, big.NewInt(101), proposal)
+
+	tests := []struct {
+		name      string
+		signerIdx int
+		proposal  *types.Block
+		seq       int64
+		round     int64
+		code      uint64
+		wantSize  int // expected backlog size for this signer after adding
+	}{
+		{
+			name:      "first message",
+			signerIdx: 1, proposal: proposal, seq: 101, round: 5, code: wbftmsg.PrepareCode,
+			wantSize: 1,
+		},
+		{
+			name:      "duplicate same slot different digest - dropped",
+			signerIdx: 1, proposal: otherProposal, seq: 101, round: 5, code: wbftmsg.PrepareCode,
+			wantSize: 1,
+		},
+		{
+			name:      "same validator different round - accepted",
+			signerIdx: 1, proposal: proposal, seq: 101, round: 6, code: wbftmsg.PrepareCode,
+			wantSize: 2,
+		},
+		{
+			name:      "same validator same slot different code - accepted",
+			signerIdx: 1, proposal: proposal, seq: 101, round: 5, code: wbftmsg.CommitCode,
+			wantSize: 3,
+		},
+		{
+			name:      "different validator same slot - accepted",
+			signerIdx: 2, proposal: proposal, seq: 101, round: 5, code: wbftmsg.PrepareCode,
+			wantSize: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := crypto.PubkeyToAddress(signers[tt.signerIdx].PublicKey)
+			addBacklogMsg(t, core, tt.code, tt.signerIdx, tt.proposal, big.NewInt(tt.seq), big.NewInt(tt.round))
+
+			if core.backlogs[src].Size() != tt.wantSize {
+				t.Errorf("backlog size = %d; want %d", core.backlogs[src].Size(), tt.wantSize)
+			}
+		})
+	}
+}
+
+// TestProcessBacklogPurgesOnValidatorRemoval verifies that both the backlog queue
+// and backlogKeys are fully purged for a validator that has left the validator set.
+func TestProcessBacklogPurgesOnValidatorRemoval(t *testing.T) {
+	proposal := makeProposal(big.NewInt(100))
+	core := makeCoreForTest(common.Big0, common.Big0, big.NewInt(101), proposal)
+
+	src := crypto.PubkeyToAddress(signers[1].PublicKey)
+	remaining := crypto.PubkeyToAddress(signers[2].PublicKey)
+	seq := big.NewInt(101)
+
+	// Add several messages from signers[1] (to be removed) and signers[2] (to remain).
+	for _, round := range []int64{1, 2, 3} {
+		addBacklogMsg(t, core, wbftmsg.PrepareCode, 1, proposal, seq, big.NewInt(round))
+	}
+	addBacklogMsg(t, core, wbftmsg.PrepareCode, 2, proposal, seq, big.NewInt(1))
+
+	if core.backlogs[src].Size() != 3 {
+		t.Fatalf("expected 3 messages in backlog before removal, got %d", core.backlogs[src].Size())
+	}
+	if len(core.backlogKeys[src]) != 3 {
+		t.Fatalf("expected 3 keys before removal, got %d", len(core.backlogKeys[src]))
+	}
+
+	// Remove signers[1] from the validator set.
+	core.valSet.RemoveValidator(src)
+
+	core.processBacklog()
+
+	// Removed validator's backlog and keys must be purged.
+	if _, exists := core.backlogs[src]; exists {
+		t.Errorf("expected backlogs entry for removed validator to be deleted")
+	}
+	if len(core.backlogKeys[src]) != 0 {
+		t.Errorf("expected backlogKeys for removed validator to be empty, got %d entries",
+			len(core.backlogKeys[src]))
+	}
+
+	// Remaining validator's backlog and keys must be intact.
+	if core.backlogs[remaining] == nil || core.backlogs[remaining].Size() != 1 {
+		t.Errorf("expected remaining validator backlog to be intact with 1 message")
+	}
+	if len(core.backlogKeys[remaining]) != 1 {
+		t.Errorf("expected remaining validator backlogKeys to be intact with 1 key, got %d",
+			len(core.backlogKeys[remaining]))
+	}
+}
+
+// TestProcessBacklogRemovesKeysOnDrop verifies that backlogKeys are removed when
+// a backlogged message is dropped because it has become expired or invalid.
+func TestProcessBacklogRemovesKeysOnDrop(t *testing.T) {
+	proposal := makeProposal(big.NewInt(100))
+	// Core at seq=101, round=0
+	core := makeCoreForTest(common.Big0, common.Big0, big.NewInt(101), proposal)
+
+	seq := big.NewInt(101)
+	round := big.NewInt(5)
+	src := crypto.PubkeyToAddress(signers[1].PublicKey)
+
+	// Add a future-round message to the backlog.
+	addBacklogMsg(t, core, wbftmsg.PrepareCode, 1, proposal, seq, round)
+
+	if _, exists := core.backlogKeys[src][backlogKey{wbftmsg.PrepareCode, seq.Uint64(), round.Uint64()}]; !exists {
+		t.Fatal("expected key to be present in backlogKeys after addToBacklog")
+	}
+
+	// Advance to round=16 (> round=5) so the backlogged message becomes old.
+	core.current = newRoundState(
+		&wbft.View{Sequence: big.NewInt(101), Round: big.NewInt(16)},
+		core.valSet, nil, nil, nil, nil, func(hash common.Hash) bool { return false },
+	)
+
+	core.processBacklog()
+
+	if len(core.backlogKeys[src]) != 0 {
+		t.Errorf("expected backlogKeys to be empty after processBacklog, got %d entries",
+			len(core.backlogKeys[src]))
+	}
+}
+
+// addBacklogMsg creates a message of the given code from signers[signerIdx]
+// and adds it to the backlog.
+func addBacklogMsg(t *testing.T, core *Core, code uint64, signerIdx int, proposal *types.Block, seq, round *big.Int) {
+	t.Helper()
+	switch code {
+	case wbftmsg.PrepareCode:
+		core.addToBacklog(createPrepareMsg(signers[signerIdx], proposal.Header(), seq, round, proposal.Hash().Bytes()))
+	case wbftmsg.CommitCode:
+		core.addToBacklog(createCommitMsg(signers[signerIdx], proposal.Header(), seq, round, proposal.Hash().Bytes()))
+	default:
+		t.Fatalf("addBacklogMsg: unsupported message code %d", code)
 	}
 }

--- a/consensus/wbft/core/core.go
+++ b/consensus/wbft/core/core.go
@@ -62,6 +62,7 @@ func New(backend Backend, config *wbft.Config) *Core {
 		logger:             log.New("address", backend.Address()),
 		backend:            backend,
 		backlogs:           make(map[common.Address]*prque.Prque[int64, wbftmessage.WBFTMessage]),
+		backlogKeys:        make(map[common.Address]map[backlogKey]struct{}),
 		backlogsMu:         new(sync.Mutex),
 		prepareExtraSeals:  make(map[common.Address]*wbftmessage.Prepare),
 		commitExtraSeals:   make(map[common.Address]*wbftmessage.Commit),
@@ -94,8 +95,9 @@ type Core struct {
 	valSet     wbft.ValidatorSet
 	validateFn func([]byte, []byte, wbft.View) (common.Address, error)
 
-	backlogs   map[common.Address]*prque.Prque[int64, wbftmessage.WBFTMessage]
-	backlogsMu *sync.Mutex
+	backlogs    map[common.Address]*prque.Prque[int64, wbftmessage.WBFTMessage]
+	backlogKeys map[common.Address]map[backlogKey]struct{}
+	backlogsMu  *sync.Mutex
 
 	prepareExtraSeals map[common.Address]*wbftmessage.Prepare
 	commitExtraSeals  map[common.Address]*wbftmessage.Commit

--- a/consensus/wbft/core/extraseal_test.go
+++ b/consensus/wbft/core/extraseal_test.go
@@ -68,6 +68,7 @@ func makeCoreForTest(priorRound, currentRound, currentSequence *big.Int, lastPro
 		logger:             log.New("address", crypto.PubkeyToAddress(signers[0].PublicKey)),
 		backend:            nil,
 		backlogs:           make(map[common.Address]*prque.Prque[int64, messages.WBFTMessage]),
+		backlogKeys:        make(map[common.Address]map[backlogKey]struct{}),
 		backlogsMu:         new(sync.Mutex),
 		prepareExtraSeals:  make(map[common.Address]*messages.Prepare),
 		commitExtraSeals:   make(map[common.Address]*messages.Commit),


### PR DESCRIPTION
## Overview

Prevent memory and CPU exhaustion DoS attacks by validating and restricting future-sequence messages in the WBFT backlog.

## Problem

Future-sequence messages (sequence = current + 1) were stored in the validator's backlog without round threshold validation nor per-validator queue size limits.

Additionally, the existing knownMessages LRU deduplicates by full payload hash, so a malicious validator can bypass it by varying fields such as Digest or Justification while keeping the same (sequence, round) coordinates, generating unlimited distinct messages for the same logical slot.

A malicious validator could spam messages to cause memory and CPU exhaustion, potentially causing liveness degradation.

## Solution

Enforce round threshold validation on future-sequence messages, cap the maximum backlog size per validator, and introduce a key-based deduplication map. Keep backlogKeys in sync by removing keys when messages are dropped or when a validator is removed.

## Changes

- Apply roundThreshold validation to future-sequence messages in isTooFarFutureMessage.
- Implement maxBacklogSizePerValidator cap to drop overflow messages in addToBacklog.
- Introduce backlogKey and backlogKeys map to prevent duplicate messages for the same slot in addToBacklog.
- Keep backlogKeys in sync by removing keys on message drop and purging all backlog metadata upon validator removal in processBacklog.